### PR TITLE
Add versioned database seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# OnlineDrinkCabinet
+# Online Drink Cabinet
+
+A cocktail recipe book backed by SQLite that helps you manage your home bar inventory and discover what you can mix with the bottles you already have.
+
+## Features
+
+- **Fridge & Pantry module** – add ingredients, tag them by category, and flip them in or out of stock. Everything is stored in a SQLite database so your inventory persists between sessions.
+- **Cocktail library** – browse a curated starter collection of spritzes, highballs, and sours. Every recipe checks against your fridge to highlight what is ready to shake and what still needs a shopping trip.
+- **Custom creations** – add new drinks with a name, searchable ingredient selector (with inline creation), and preparation instructions. Ingredients are automatically linked in the database so availability stays in sync.
+- **Server-side API** – the front end fetches data from a tiny Express API, which you can extend or connect to other clients if needed.
+
+## Requirements
+
+- [Node.js](https://nodejs.org/) 18 or newer (ships with `npm`)
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the API and web server:
+   ```bash
+   npm start
+   ```
+3. Open [http://localhost:1933](http://localhost:1933) in your browser. The Express server serves the static front-end files and the JSON API at the same port.
+
+The first start seeds the SQLite database (`data/cabinet.db`) with a base catalogue of ingredients and drinks. Subsequent launches reuse the same file so your additions persist, and seeding only re-runs when the bundled dataset version changes.
+
+## Development tips
+
+- The API lives in `server.js`. It exposes `/api/ingredients` and `/api/drinks` endpoints for listing, creating, and updating data.
+- Ingredient inventory is toggled with `PATCH /api/ingredients/:id`. Use `POST /api/ingredients/reset` to clear stock flags without removing entries.
+- Drinks created through the UI automatically create missing ingredients in the catalogue (marked out of stock by default) so you can immediately manage them in the fridge module.
+
+To iterate faster while developing, you can run the server with hot reload using `npm run dev` (requires `nodemon`, installed as a dev dependency).
+
+## Function overview
+
+### Server (`server.js`)
+
+- `migrate()` – ensures the SQLite schema for ingredients, drinks, and their join table exists before handling requests.
+- `seedIngredients()` – inserts the starter ingredient catalogue while keeping any user-supplied categories intact (data lives in `seed/defaultData.js`).
+- `seedDrinks()` – loads the base drink recipes from `seed/defaultData.js`, linking them to the corresponding ingredients.
+- `normaliseIngredientName(name)` – trims and collapses whitespace so ingredient and drink names stay consistent.
+- Express route handlers – serve and mutate ingredient and drink data (`/api/ingredients`, `/api/drinks`) with validation and error handling.
+
+### Client (`app.js`)
+
+- `fetchJSON(url, options)` – wraps `fetch` calls, throwing helpful errors when responses fail.
+- `loadIngredients()` / `loadDrinks()` – hydrate the UI state from the API and trigger rendering.
+- `updateIngredientCatalog()` – keeps the datalist suggestions for ingredient names current.
+- `syncDrinkAvailability()` – merges fridge stock levels into each drink so availability badges stay accurate.
+- `renderIngredients()` / `renderDrinks()` – build the DOM for the fridge pills and drink cards, including empty states and badges.
+- `summariseDrink(drink)` / `shouldDisplayDrink(drink)` – compute aggregate stats for filtering and status messaging.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,477 @@
+const state = {
+  ingredients: [],
+  drinks: [],
+  filter: 'all',
+  drinkFormIngredients: []
+};
+
+const elements = {
+  ingredientForm: document.getElementById('add-ingredient-form'),
+  ingredientName: document.getElementById('ingredient-input'),
+  ingredientCategory: document.getElementById('ingredient-category'),
+  ingredientList: document.getElementById('inventory-list'),
+  inventoryCount: document.querySelector('.inventory-count'),
+  resetInventory: document.getElementById('reset-inventory'),
+  ingredientCatalog: document.getElementById('ingredient-catalog'),
+  drinkForm: document.getElementById('add-drink-form'),
+  drinkName: document.getElementById('drink-name'),
+  drinkIngredientSearch: document.getElementById('drink-ingredient-search'),
+  drinkIngredientCatalog: document.getElementById('drink-ingredient-catalog'),
+  selectedDrinkIngredients: document.getElementById('selected-ingredients'),
+  addIngredientToDrink: document.getElementById('add-ingredient-to-drink'),
+  drinkIngredients: document.getElementById('drink-ingredients'),
+  drinkRecipe: document.getElementById('drink-recipe'),
+  drinksList: document.getElementById('drinks-list'),
+  filterButtons: document.querySelectorAll('.drinks-filter .chip'),
+  drinkTemplate: document.getElementById('drink-template')
+};
+
+async function fetchJSON(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const message = await response.json().catch(() => ({ message: 'Request failed' }));
+    throw new Error(message.message || 'Request failed');
+  }
+  return response.json();
+}
+
+async function loadIngredients() {
+  const data = await fetchJSON('/api/ingredients');
+  state.ingredients = data;
+  syncDrinkAvailability();
+  renderIngredients();
+  updateIngredientCatalog();
+  renderDrinks();
+}
+
+async function loadDrinks() {
+  const data = await fetchJSON('/api/drinks');
+  state.drinks = data;
+  syncDrinkAvailability();
+  renderDrinks();
+}
+
+function updateIngredientCatalog() {
+  elements.ingredientCatalog.innerHTML = '';
+  elements.drinkIngredientCatalog.innerHTML = '';
+  const sorted = [...state.ingredients].sort((a, b) => a.name.localeCompare(b.name));
+  for (const ingredient of sorted) {
+    const option = document.createElement('option');
+    option.value = ingredient.name;
+    elements.ingredientCatalog.append(option);
+
+    const drinkOption = document.createElement('option');
+    drinkOption.value = ingredient.name;
+    elements.drinkIngredientCatalog.append(drinkOption);
+  }
+}
+
+function updateDrinkAvailability(drinks, availability) {
+  return drinks.map((drink) => {
+    const ingredients = drink.ingredients.map((ingredient) => {
+      const inStock = availability.has(ingredient.id)
+        ? availability.get(ingredient.id)
+        : ingredient.inStock;
+      return { ...ingredient, inStock: !!inStock };
+    });
+
+    const total = ingredients.length;
+    const availableCount = ingredients.filter((item) => item.inStock).length;
+    const missingNames = ingredients.filter((item) => !item.inStock).map((item) => item.name);
+
+    return {
+      ...drink,
+      ingredients,
+      availability: {
+        total,
+        available: availableCount,
+        missing: missingNames
+      }
+    };
+  });
+}
+
+function syncDrinkAvailability() {
+  const availability = new Map(state.ingredients.map((item) => [item.id, item.inStock]));
+  state.drinks = updateDrinkAvailability(state.drinks, availability);
+}
+
+function renderIngredientPill(ingredient) {
+  const item = document.createElement('li');
+  item.className = `pill ${ingredient.inStock ? 'pill-active' : ''}`;
+  item.dataset.id = ingredient.id;
+  item.setAttribute('role', 'button');
+  item.tabIndex = 0;
+  item.title = ingredient.inStock ? 'Mark as out of stock' : 'Mark as in stock';
+  item.textContent = ingredient.name;
+  item.addEventListener('click', () => toggleIngredient(ingredient.id, !ingredient.inStock));
+  item.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleIngredient(ingredient.id, !ingredient.inStock);
+    }
+  });
+  return item;
+}
+
+function renderIngredients() {
+  const inStockCount = state.ingredients.filter((item) => item.inStock).length;
+  if (state.ingredients.length === 0) {
+    elements.inventoryCount.textContent = 'No ingredients saved yet.';
+  } else {
+    const summary = `${inStockCount} of ${state.ingredients.length} ingredient${
+      state.ingredients.length === 1 ? '' : 's'
+    } in stock`;
+    elements.inventoryCount.textContent = summary;
+  }
+
+  elements.ingredientList.innerHTML = '';
+  if (state.ingredients.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Add items to your fridge to start tracking availability.';
+    elements.ingredientList.append(empty);
+    return;
+  }
+
+  const sorted = [...state.ingredients].sort((a, b) => a.name.localeCompare(b.name));
+  for (const ingredient of sorted) {
+    elements.ingredientList.append(renderIngredientPill(ingredient));
+  }
+}
+
+function normaliseIngredientInput(name) {
+  return name.trim().replace(/\s+/g, ' ');
+}
+
+function resolveIngredientName(value) {
+  const cleanValue = normaliseIngredientInput(value);
+  if (!cleanValue) return '';
+  const existing = state.ingredients.find((item) => item.name.toLowerCase() === cleanValue.toLowerCase());
+  return existing ? existing.name : cleanValue;
+}
+
+function renderSelectedDrinkIngredients() {
+  const list = elements.selectedDrinkIngredients;
+  list.innerHTML = '';
+
+  if (state.drinkFormIngredients.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'selector-empty';
+    empty.textContent = 'No ingredients yet. Search and add from the field below.';
+    list.append(empty);
+    return;
+  }
+
+  state.drinkFormIngredients.forEach((name, index) => {
+    const item = document.createElement('li');
+    item.className = 'selector-pill';
+
+    const label = document.createElement('span');
+    label.textContent = name;
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'remove-pill';
+    remove.dataset.index = index;
+    remove.setAttribute('aria-label', `Remove ${name}`);
+    remove.textContent = '×';
+
+    item.append(label, remove);
+    list.append(item);
+  });
+}
+
+function updateDrinkFormState() {
+  elements.drinkIngredients.value = state.drinkFormIngredients.join(', ');
+  if (state.drinkFormIngredients.length > 0) {
+    elements.drinkIngredientSearch.setCustomValidity('');
+  }
+}
+
+function addDrinkIngredient(rawValue) {
+  const resolvedName = resolveIngredientName(rawValue || '');
+  if (!resolvedName) {
+    return;
+  }
+
+  const exists = state.drinkFormIngredients.some(
+    (item) => item.toLowerCase() === resolvedName.toLowerCase()
+  );
+  if (exists) {
+    elements.drinkIngredientSearch.value = '';
+    return;
+  }
+
+  state.drinkFormIngredients.push(resolvedName);
+  renderSelectedDrinkIngredients();
+  updateDrinkFormState();
+  elements.drinkIngredientSearch.value = '';
+  elements.drinkIngredientSearch.focus();
+}
+
+function removeDrinkIngredient(index) {
+  if (index < 0 || index >= state.drinkFormIngredients.length) {
+    return;
+  }
+  state.drinkFormIngredients.splice(index, 1);
+  renderSelectedDrinkIngredients();
+  updateDrinkFormState();
+}
+
+function resetDrinkForm() {
+  state.drinkFormIngredients = [];
+  elements.drinkForm.reset();
+  elements.drinkIngredientSearch.value = '';
+  renderSelectedDrinkIngredients();
+  updateDrinkFormState();
+}
+
+function summariseDrink(drink) {
+  if (drink.availability) {
+    const missingNames = new Set(
+      Array.isArray(drink.availability.missing)
+        ? drink.availability.missing.map((name) => name.toLowerCase())
+        : []
+    );
+    const missingFromList = drink.ingredients.filter((ingredient) =>
+      missingNames.has(ingredient.name.toLowerCase())
+    );
+    const total = drink.availability.total ?? drink.ingredients.length;
+    const available = drink.availability.available ?? drink.ingredients.length - missingFromList.length;
+    return {
+      total,
+      available,
+      missing: missingFromList,
+      ready: total > 0 && missingFromList.length === 0
+    };
+  }
+
+  const total = drink.ingredients.length;
+  const available = drink.ingredients.filter((ingredient) => ingredient.inStock).length;
+  const missing = drink.ingredients.filter((ingredient) => !ingredient.inStock);
+  return {
+    total,
+    available,
+    missing,
+    ready: total > 0 && missing.length === 0
+  };
+}
+
+function shouldDisplayDrink(drink) {
+  const summary = summariseDrink(drink);
+  switch (state.filter) {
+    case 'ready':
+      return summary.ready;
+    case 'missing':
+      return summary.missing.length > 0;
+    default:
+      return true;
+  }
+}
+
+function renderDrinkCard(drink) {
+  const node = elements.drinkTemplate.content.cloneNode(true);
+  const listItem = node.querySelector('.drink-card');
+  listItem.dataset.drinkId = drink.id;
+
+  const summary = summariseDrink(drink);
+
+  node.querySelector('.drink-title').textContent = drink.name;
+  node.querySelector('.drink-recipe').textContent = drink.instructions;
+
+  const status = node.querySelector('.drink-status');
+  const badge = node.querySelector('.drink-badge');
+  if (summary.ready) {
+    status.textContent = 'Ready to mix';
+    badge.textContent = 'Ready';
+    badge.className = 'drink-badge badge-ready';
+  } else if (summary.missing.length === summary.total) {
+    status.textContent = 'Missing every ingredient';
+    badge.textContent = 'Out';
+    badge.className = 'drink-badge badge-missing';
+  } else {
+    status.textContent = `Missing ${summary.missing.length} of ${summary.total}`;
+    badge.textContent = `${summary.available}/${summary.total}`;
+    badge.className = 'drink-badge badge-partial';
+  }
+
+  const ingredientList = node.querySelector('.ingredient-list');
+  ingredientList.innerHTML = '';
+  for (const ingredient of drink.ingredients) {
+    const ingredientItem = document.createElement('li');
+    ingredientItem.textContent = ingredient.name;
+    if (ingredient.inStock) {
+      ingredientItem.classList.add('ingredient-ready');
+    } else {
+      ingredientItem.classList.add('ingredient-missing');
+    }
+    ingredientList.append(ingredientItem);
+  }
+
+  const missingText = node.querySelector('.missing-ingredients');
+  if (summary.missing.length > 0) {
+    missingText.textContent = `Missing: ${summary.missing.map((item) => item.name).join(', ')}`;
+  } else {
+    missingText.textContent = 'Everything you need is on hand.';
+  }
+
+  return node;
+}
+
+function renderDrinks() {
+  elements.drinksList.innerHTML = '';
+  if (state.drinks.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'No drinks saved yet. Add one above to get started.';
+    elements.drinksList.append(empty);
+    return;
+  }
+
+  const drinksToShow = state.drinks.filter(shouldDisplayDrink);
+  if (drinksToShow.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent =
+      state.filter === 'ready'
+        ? 'Nothing is fully stocked yet. Add more ingredients to unlock drinks.'
+        : 'Everything here is ready to shake. Switch filters to explore more.';
+    elements.drinksList.append(empty);
+    return;
+  }
+
+  for (const drink of drinksToShow) {
+    elements.drinksList.append(renderDrinkCard(drink));
+  }
+}
+
+async function toggleIngredient(id, inStock) {
+  try {
+    await fetchJSON(`/api/ingredients/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ inStock })
+    });
+    await loadIngredients();
+  } catch (error) {
+    console.error(error);
+    alert(error.message);
+  }
+}
+
+async function handleIngredientSubmit(event) {
+  event.preventDefault();
+  const name = elements.ingredientName.value.trim();
+  const category = elements.ingredientCategory.value.trim();
+  if (!name) return;
+
+  try {
+    await fetchJSON('/api/ingredients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, category: category || null, inStock: true })
+    });
+    elements.ingredientForm.reset();
+    await loadIngredients();
+  } catch (error) {
+    console.error(error);
+    alert(error.message);
+  }
+}
+
+async function handleResetInventory() {
+  try {
+    await fetchJSON('/api/ingredients/reset', { method: 'POST' });
+    await loadIngredients();
+  } catch (error) {
+    console.error(error);
+    alert('Unable to reset inventory.');
+  }
+}
+
+async function handleDrinkSubmit(event) {
+  event.preventDefault();
+  elements.drinkIngredientSearch.setCustomValidity('');
+  const name = elements.drinkName.value.trim();
+  const instructions = elements.drinkRecipe.value.trim();
+  const ingredientsInput = state.drinkFormIngredients.map((value) => value.trim()).filter(Boolean);
+
+  if (!name || !instructions || ingredientsInput.length === 0) {
+    if (ingredientsInput.length === 0) {
+      elements.drinkIngredientSearch.setCustomValidity('Add at least one ingredient to the drink.');
+      elements.drinkIngredientSearch.reportValidity();
+    }
+    return;
+  }
+
+  try {
+    await fetchJSON('/api/drinks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, instructions, ingredients: ingredientsInput })
+    });
+    resetDrinkForm();
+    await Promise.all([loadDrinks(), loadIngredients()]);
+  } catch (error) {
+    console.error(error);
+    alert(error.message);
+  }
+}
+
+function handleFilterClick(event) {
+  const button = event.target.closest('button[data-filter]');
+  if (!button) return;
+  state.filter = button.dataset.filter;
+  elements.filterButtons.forEach((chip) => chip.classList.toggle('chip-active', chip === button));
+  renderDrinks();
+}
+
+function handleDrinkIngredientSelection(event) {
+  addDrinkIngredient(event.target.value);
+}
+
+function handleDrinkIngredientKeydown(event) {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    addDrinkIngredient(event.target.value);
+  } else if (event.key === 'Backspace' && event.target.value === '') {
+    removeDrinkIngredient(state.drinkFormIngredients.length - 1);
+  }
+}
+
+function handleSelectedIngredientClick(event) {
+  const button = event.target.closest('button[data-index]');
+  if (!button) return;
+  const index = Number.parseInt(button.dataset.index, 10);
+  if (Number.isNaN(index)) return;
+  removeDrinkIngredient(index);
+}
+
+function handleAddIngredientButton() {
+  addDrinkIngredient(elements.drinkIngredientSearch.value);
+}
+
+function setupEventListeners() {
+  elements.ingredientForm.addEventListener('submit', handleIngredientSubmit);
+  elements.resetInventory.addEventListener('click', handleResetInventory);
+  elements.drinkForm.addEventListener('submit', handleDrinkSubmit);
+  document.querySelector('.drinks-filter').addEventListener('click', handleFilterClick);
+  elements.drinkIngredientSearch.addEventListener('change', handleDrinkIngredientSelection);
+  elements.drinkIngredientSearch.addEventListener('keydown', handleDrinkIngredientKeydown);
+  elements.selectedDrinkIngredients.addEventListener('click', handleSelectedIngredientClick);
+  elements.addIngredientToDrink.addEventListener('click', handleAddIngredientButton);
+}
+
+async function bootstrap() {
+  setupEventListeners();
+  renderSelectedDrinkIngredients();
+  updateDrinkFormState();
+  try {
+    await Promise.all([loadIngredients(), loadDrinks()]);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+bootstrap();

--- a/docs/code-analysis.md
+++ b/docs/code-analysis.md
@@ -1,0 +1,40 @@
+# Codebase Analysis
+
+## Backend (`server.js`)
+
+### Observations
+- **Database setup**: The `migrate`, `seedIngredients`, and `seedDrinks` functions handle schema creation and initial data seeding for ingredients and drinks using SQLite and synchronous transactions. They ensure idempotent seeding via `INSERT OR IGNORE` and conflict handling, but the seed routines run on every server start which can be costly as the dataset grows and mixes concerns with runtime logic. 【F:server.js†L99-L154】
+- **API structure**: REST endpoints under `/api/ingredients` and `/api/drinks` manage CRUD-like operations, however there is no validation around ingredient category formats and no pagination or sorting parameters for future scalability. Error handling is centralised in an Express error middleware but the code surfaces only a generic message to clients. 【F:server.js†L156-L318】
+- **Normalisation helper**: `normaliseIngredientName` trims and collapses whitespace for reuse in both ingredient creation and drink management. Similar cleansing could be extended to instructions to avoid duplicate whitespace. 【F:server.js†L146-L147】
+- **Drink creation transaction**: When adding drinks, the server creates missing ingredients automatically and links them within a transaction, but does not align the casing or category for these new ingredients, leading to orphaned metadata unless the user edits later. Additionally, there is no rollback on unique constraint failures for ingredient links prior to the manual cleanup, leaving potential partial data if a later step fails outside the explicit `transaction()` call. 【F:server.js†L244-L310】
+
+### Potential Improvements
+1. **Introduce service-layer helpers** to encapsulate ingredient CRUD operations and drink assembly instead of manipulating SQLite statements in each route. This would simplify testing and reduce duplication.
+2. **Add validation utilities** (e.g. for categories and instruction length) to keep route handlers focused on HTTP logic.
+3. **Implement seed gating** (e.g. a `isDatabaseSeeded` flag or migration versioning) to avoid repeated seed work and enable migrations.
+4. **Expose availability summaries** directly from the API to avoid recomputing on the client and to support other consumers.
+
+## Frontend (`app.js`)
+
+### Observations
+- **State management**: A global `state` object tracks ingredients, drinks, filter, and drink form ingredients. Synchronisation between ingredient stock updates and drink availability happens in `syncDrinkAvailability`, but this mutates the `state.drinks` array directly, which can complicate future reconciliation with server responses. 【F:app.js†L1-L83】
+- **Rendering**: DOM updates are handled via vanilla JS templating. Functions like `renderIngredients` and `renderDrinks` regenerate entire lists. Without diffing, this is acceptable for small datasets but may become inefficient as the catalog grows. 【F:app.js†L58-L210】
+- **Form handling**: The drink form tracks selected ingredients via chips, but the underlying hidden input `elements.drinkIngredients` acts as a serialised mirror primarily for validation messaging. Real validation is performed manually, and there is no feedback for duplicate additions beyond silently ignoring them. 【F:app.js†L84-L199】
+- **Event binding**: `setupEventListeners` binds all handlers on bootstrap; there is no teardown, which is fine for the single-page app but worth noting for modularisation. 【F:app.js†L312-L347】
+
+### Potential Improvements
+1. **Adopt a state update helper** (e.g. `updateState(partial)`), ensuring all renderers are triggered from a single point, making future transition to reactive frameworks easier.
+2. **Extract reusable render functions** for pills/chips to avoid duplication and enable unit testing of UI generation logic.
+3. **Add debounced search** for ingredient catalog lookups, enabling asynchronous queries when the dataset eventually moves server-side.
+4. **Introduce client-side services** (e.g. `api.ingredients` and `api.drinks`) to abstract fetch calls and centralise error handling.
+5. **Improve validation feedback** by surfacing inline error messages for empty drink names or instructions, not just ingredients.
+
+## Suggested New Helper Functions
+- `validateDrinkPayload({ name, instructions, ingredients })`: Shared server-side validation returning detailed error codes for route handlers. 【F:server.js†L244-L276】
+- `ensureIngredient(name, { category })`: Encapsulate the lookup/create logic for ingredients when creating drinks, optionally updating metadata when new ingredients are added. 【F:server.js†L286-L304】
+- `getDrinkWithAvailability(drinkId)`: Query drinks and their ingredients with in-stock summaries, useful for both POST responses and future detail views. 【F:server.js†L210-L233】【F:server.js†L305-L318】
+- `updateDrinkAvailability(drinks, ingredientAvailability)`: Pure client helper returning a new array, keeping state updates immutable. 【F:app.js†L64-L83】
+- `renderIngredientPill(ingredient)`: Generate a single pill element to make `renderIngredients` cleaner and easier to test. 【F:app.js†L99-L142】
+- `renderDrinkCard(drink)`: Wrap the template clone logic to isolate DOM construction. 【F:app.js†L152-L210】
+
+These functions would modularise responsibilities, paving the way for more robust testing and future framework migrations.

--- a/docs/conflict-resolution.md
+++ b/docs/conflict-resolution.md
@@ -1,0 +1,44 @@
+# Resolving Merge Conflicts for the Drink Cabinet Project
+
+GitHub reports merge conflicts when the target branch (usually `main`) has
+changed in the same files and sections that your pull request touches. In this
+case the conflict message lists `README.md`, `app.js`, `index.html`,
+`server.js`, and `styles.css`. That means the current `main` branch has edits in
+those files that overlap with the versions in your feature branch.
+
+To resolve the situation you need to sync your branch with the latest `main`
+changes and reconcile any overlapping edits locally before pushing an updated
+commit.
+
+## Quick resolution steps
+
+1. **Fetch the latest `main`:**
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+2. **Return to your feature branch and merge `main`:**
+   ```bash
+   git checkout work
+   git merge main
+   ```
+   Git will stop at each conflicted file and mark the conflicting sections with
+   `<<<<<<<`, `=======`, and `>>>>>>>` markers.
+3. **Open the listed files** (`README.md`, `app.js`, `index.html`, `server.js`,
+   `styles.css`) and decide how to keep both sets of desired changes. Remove the
+   conflict markers once you have the correct combined content.
+4. **Mark the files as resolved and commit:**
+   ```bash
+   git add README.md app.js index.html server.js styles.css
+   git commit
+   ```
+5. **Push the updated branch:**
+   ```bash
+   git push origin work
+   ```
+   Your pull request should now show as mergeable on GitHub.
+
+If you prefer rebasing, you can rebase your branch onto `main` (`git rebase
+main`) instead of merging. The important part is resolving the conflicts locally
+and pushing the updated result so GitHub sees a conflict-free branch.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Online Drink Cabinet</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Work+Sans:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Online Drink Cabinet</h1>
+    <p class="tagline">Keep track of your bar cart and explore cocktails you can make right now.</p>
+  </header>
+
+  <main class="app-layout">
+    <section class="card" aria-labelledby="fridge-heading">
+      <div class="section-header">
+        <h2 id="fridge-heading">Fridge &amp; Pantry</h2>
+        <p>Manage the ingredients you currently have in stock.</p>
+      </div>
+
+      <form id="add-ingredient-form" class="form-grid" autocomplete="off">
+        <label class="form-control">
+          <span>Ingredient name</span>
+          <input type="text" id="ingredient-input" list="ingredient-catalog" placeholder="e.g. Gin" required />
+        </label>
+        <label class="form-control">
+          <span>Category <small>(optional)</small></span>
+          <input type="text" id="ingredient-category" placeholder="e.g. Base Spirit" />
+        </label>
+        <button type="submit" class="primary-btn">Add ingredient</button>
+      </form>
+
+      <datalist id="ingredient-catalog"></datalist>
+
+      <div class="inventory-controls">
+        <div class="inventory-count" aria-live="polite"></div>
+        <button type="button" id="reset-inventory" class="link-btn">Clear all</button>
+      </div>
+
+      <ul id="inventory-list" class="pill-list" aria-live="polite"></ul>
+    </section>
+
+    <section class="card" aria-labelledby="drinks-heading">
+      <div class="section-header">
+        <h2 id="drinks-heading">Cocktail Library</h2>
+        <p>Browse existing drinks or add your own favourites.</p>
+      </div>
+
+      <form id="add-drink-form" class="stacked-form" autocomplete="off">
+        <div class="form-row">
+          <label class="form-control">
+            <span>Drink name</span>
+            <input type="text" id="drink-name" placeholder="e.g. French 75" required />
+          </label>
+          <label class="form-control">
+            <span>Ingredients</span>
+            <div class="ingredient-selector">
+              <ul
+                id="selected-ingredients"
+                class="selected-ingredients"
+                aria-live="polite"
+                aria-label="Selected ingredients"
+              ></ul>
+              <div class="selector-controls">
+                <input
+                  type="text"
+                  id="drink-ingredient-search"
+                  list="drink-ingredient-catalog"
+                  placeholder="Search ingredients"
+                  aria-describedby="drink-ingredient-help"
+                />
+                <button type="button" id="add-ingredient-to-drink" class="secondary-btn">Add</button>
+              </div>
+            </div>
+            <p class="field-help" id="drink-ingredient-help">
+              Search your fridge for existing ingredients or type a new one and press Add.
+            </p>
+            <input type="hidden" id="drink-ingredients" />
+          </label>
+        </div>
+        <datalist id="drink-ingredient-catalog"></datalist>
+        <label class="form-control">
+          <span>Recipe / Instructions</span>
+          <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>
+        </label>
+        <button type="submit" class="primary-btn">Add drink</button>
+      </form>
+
+      <div class="drinks-filter" role="group" aria-label="Filter drinks">
+        <button type="button" data-filter="all" class="chip chip-active">All drinks</button>
+        <button type="button" data-filter="ready" class="chip">Ready to mix</button>
+        <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
+      </div>
+
+      <ul id="drinks-list" class="drinks-list" aria-live="polite"></ul>
+    </section>
+  </main>
+
+  <template id="drink-template">
+    <li class="drink-card">
+      <header class="drink-header">
+        <div>
+          <h3 class="drink-title"></h3>
+          <p class="drink-status"></p>
+        </div>
+        <span class="drink-badge" aria-hidden="true"></span>
+      </header>
+      <details class="drink-details">
+        <summary>
+          <span>Ingredients</span>
+        </summary>
+        <ul class="ingredient-list"></ul>
+        <p class="missing-ingredients"></p>
+        <h4>Method</h4>
+        <p class="drink-recipe"></p>
+      </details>
+    </li>
+  </template>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1641 @@
+{
+  "name": "online-drink-cabinet",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "online-drink-cabinet",
+      "version": "1.0.0",
+      "dependencies": {
+        "better-sqlite3": "^8.7.0",
+        "cors": "^2.8.5",
+        "express": "^4.19.2"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
+      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
+      "integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "online-drink-cabinet",
+  "version": "1.0.0",
+  "description": "Recipe book for cocktails with ingredient inventory, backed by SQLite.",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^8.7.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/seed/defaultData.js
+++ b/seed/defaultData.js
@@ -1,0 +1,219 @@
+const baseIngredients = [
+  { name: 'Vodka', category: 'Base Spirit' },
+  { name: 'White rum', category: 'Base Spirit' },
+  { name: 'Gin', category: 'Base Spirit' },
+  { name: 'Tequila (silver)', category: 'Base Spirit' },
+  { name: 'Triple sec', category: 'Liqueur' },
+  { name: 'Peach schnapps', category: 'Liqueur' },
+  { name: 'Coconut rum', category: 'Liqueur' },
+  { name: 'Pineapple juice', category: 'Juice' },
+  { name: 'Cranberry juice', category: 'Juice' },
+  { name: 'Orange juice', category: 'Juice' },
+  { name: 'Lime juice', category: 'Juice' },
+  { name: 'Lemon juice', category: 'Juice' },
+  { name: 'Grapefruit juice', category: 'Juice' },
+  { name: 'Simple syrup', category: 'Syrup' },
+  { name: 'Grenadine', category: 'Syrup' },
+  { name: 'Passion fruit syrup', category: 'Syrup' },
+  { name: 'Orgeat', category: 'Syrup' },
+  { name: 'Cola', category: 'Soda' },
+  { name: 'Ginger beer', category: 'Soda' },
+  { name: 'Tonic water', category: 'Soda' },
+  { name: 'Sparkling water', category: 'Soda' },
+  { name: 'Prosecco', category: 'Wine' },
+  { name: 'Bitters', category: 'Aromatic' },
+  { name: 'Elderflower syrup', category: 'Syrup' },
+  { name: 'Vanilla syrup', category: 'Syrup' },
+  { name: 'Coconut cream', category: 'Mixer' },
+  { name: 'Cucumber', category: 'Garnish' },
+  { name: 'Mint leaves', category: 'Herb' },
+  { name: 'Maraschino cherries', category: 'Garnish' },
+  { name: 'Edible flowers', category: 'Garnish' }
+];
+
+const baseDrinks = [
+  {
+    name: 'French 75',
+    ingredients: ['Gin', 'Lemon juice', 'Simple syrup', 'Prosecco'],
+    instructions:
+      'Add 45 ml gin, 20 ml lemon juice, and 15 ml simple syrup to a shaker with ice. Shake for 10 s, strain into a flute, and top with 60 ml prosecco. Garnish with lemon peel.'
+  },
+  {
+    name: 'Piña Colada',
+    ingredients: ['White rum', 'Coconut cream', 'Pineapple juice'],
+    instructions:
+      'Blend 60 ml rum, 90 ml pineapple juice, and 30 ml coconut cream with ice until smooth. Pour into a chilled glass and garnish with cherry and pineapple wedge.'
+  },
+  {
+    name: 'Elderflower Gin & Tonic',
+    ingredients: ['Gin', 'Tonic water', 'Elderflower syrup', 'Lime juice'],
+    instructions:
+      'Add 45 ml gin, 10 ml elderflower syrup, and 10 ml lime juice to a glass of ice. Top with 120 ml tonic water. Stir gently and garnish with cucumber.'
+  },
+  {
+    name: 'Cucumber Vodka Tonic',
+    ingredients: ['Vodka', 'Tonic water', 'Cucumber', 'Lime juice'],
+    instructions:
+      'Muddle three cucumber slices in glass. Add 45 ml vodka and ice. Top with 120 ml tonic and 10 ml lime juice. Stir once.'
+  },
+  {
+    name: 'Vodka Spritz',
+    ingredients: ['Vodka', 'Elderflower syrup', 'Sparkling water', 'Lemon juice'],
+    instructions:
+      'Combine 45 ml vodka, 10 ml elderflower syrup, and 15 ml lemon juice in glass with ice. Top with 100 ml sparkling water. Stir.'
+  },
+  {
+    name: 'Grapefruit Spritz',
+    ingredients: ['Vodka', 'Grapefruit juice', 'Prosecco'],
+    instructions:
+      'Combine 45 ml vodka and 60 ml grapefruit juice in glass. Add ice, top with 90 ml prosecco, stir once. Garnish grapefruit peel.'
+  },
+  {
+    name: 'Bay Breeze',
+    ingredients: ['Vodka', 'Pineapple juice', 'Cranberry juice'],
+    instructions:
+      'Shake 45 ml vodka, 60 ml pineapple, and 60 ml cranberry juice with ice. Strain into tall glass with fresh ice.'
+  },
+  {
+    name: 'Sea Breeze',
+    ingredients: ['Vodka', 'Cranberry juice', 'Grapefruit juice'],
+    instructions:
+      'Shake 45 ml vodka, 60 ml cranberry, and 45 ml grapefruit juice with ice. Strain into ice-filled glass.'
+  },
+  {
+    name: 'Malibu Sunrise',
+    ingredients: ['Coconut rum', 'Orange juice', 'Grenadine'],
+    instructions:
+      'Add 45 ml coconut rum and 90 ml orange juice to glass with ice. Slowly pour 15 ml grenadine for gradient.'
+  },
+  {
+    name: 'Tequila Sunrise',
+    ingredients: ['Tequila (silver)', 'Orange juice', 'Grenadine'],
+    instructions:
+      'Add 45 ml tequila and 90 ml orange juice to glass. Slowly pour 15 ml grenadine. Do not stir.'
+  },
+  {
+    name: 'Rum Punch',
+    ingredients: ['White rum', 'Pineapple juice', 'Orange juice', 'Grenadine', 'Lime juice'],
+    instructions:
+      'Shake 60 ml rum, 60 ml pineapple, 60 ml orange, 15 ml grenadine, 10 ml lime juice with ice. Strain.'
+  },
+  {
+    name: 'Passion Fruit Cooler',
+    ingredients: ['Vodka', 'Passion fruit syrup', 'Lime juice', 'Sparkling water'],
+    instructions:
+      'Shake 45 ml vodka, 20 ml passion fruit syrup, and 10 ml lime juice. Strain into glass, top with 100 ml sparkling water.'
+  },
+  {
+    name: 'Peach Paradise',
+    ingredients: ['Peach schnapps', 'Orange juice', 'Grenadine'],
+    instructions:
+      'Add 45 ml schnapps and 90 ml orange juice over ice. Drizzle 10 ml grenadine.'
+  },
+  {
+    name: 'Tropical Fizz',
+    ingredients: ['White rum', 'Pineapple juice', 'Sparkling water'],
+    instructions:
+      'Build with 45 ml rum and 90 ml pineapple juice. Top with 100 ml sparkling water. Stir once.'
+  },
+  {
+    name: 'Vanilla Colada',
+    ingredients: ['Coconut rum', 'Vanilla syrup', 'Coconut cream', 'Pineapple juice'],
+    instructions:
+      'Shake 45 ml coconut rum, 15 ml vanilla syrup, 30 ml coconut cream, 90 ml pineapple juice. Strain into glass with crushed ice.'
+  },
+  {
+    name: 'Lemon Drop',
+    ingredients: ['Vodka', 'Lemon juice', 'Simple syrup', 'Triple sec'],
+    instructions:
+      'Shake 45 ml vodka, 15 ml triple sec, 20 ml lemon juice, 15 ml simple syrup with ice. Fine strain into coupe.'
+  },
+  {
+    name: 'Margarita Classic',
+    ingredients: ['Tequila (silver)', 'Lime juice', 'Triple sec', 'Simple syrup'],
+    instructions:
+      'Shake 45 ml tequila, 15 ml triple sec, 20 ml lime juice, 10 ml simple syrup. Strain over ice. Garnish lime wedge.'
+  },
+  {
+    name: 'Rum Sour',
+    ingredients: ['White rum', 'Lemon juice', 'Orgeat'],
+    instructions:
+      'Shake 45 ml rum, 25 ml lemon juice, 15 ml orgeat. Strain into rocks glass with ice.'
+  },
+  {
+    name: 'French Blossom',
+    ingredients: ['Gin', 'Elderflower syrup', 'Lemon juice', 'Prosecco'],
+    instructions:
+      'Shake 45 ml gin, 15 ml elderflower syrup, 15 ml lemon juice with ice. Strain into flute. Top with 60 ml prosecco.'
+  },
+  {
+    name: 'Moscow Mule',
+    ingredients: ['Vodka', 'Lime juice', 'Ginger beer'],
+    instructions:
+      'Add 45 ml vodka and 10 ml lime juice to mug. Add ice, top with 120 ml ginger beer. Stir gently.'
+  },
+  {
+    name: 'Rum Mule',
+    ingredients: ['White rum', 'Lime juice', 'Ginger beer'],
+    instructions: 'Same as Moscow Mule but with rum. Garnish mint.'
+  },
+  {
+    name: 'Cuba Libre',
+    ingredients: ['White rum', 'Cola', 'Lime juice'],
+    instructions:
+      'Add 45 ml rum and 10 ml lime juice to glass of ice. Top with 120 ml cola.'
+  },
+  {
+    name: 'Sex on the Beach',
+    ingredients: ['Vodka', 'Peach schnapps', 'Cranberry juice', 'Orange juice'],
+    instructions:
+      'Add 30 ml vodka, 30 ml schnapps, 60 ml cranberry, 60 ml orange juice. Stir.'
+  },
+  {
+    name: 'Paloma Highball',
+    ingredients: ['Tequila (silver)', 'Grapefruit juice', 'Sparkling water', 'Simple syrup', 'Lime juice'],
+    instructions:
+      'Shake tequila, 60 ml grapefruit, 10 ml lime, 10 ml simple syrup. Pour over ice. Top with sparkling water.'
+  },
+  {
+    name: 'Southside Spritz',
+    ingredients: ['Gin', 'Lemon juice', 'Simple syrup', 'Mint leaves', 'Sparkling water'],
+    instructions:
+      'Muddle 6 mint leaves, add 45 ml gin, 15 ml lemon, 15 ml simple syrup, ice, top with sparkling water.'
+  },
+  {
+    name: 'Mai Tai Light',
+    ingredients: ['White rum', 'Lime juice', 'Orgeat', 'Triple sec'],
+    instructions:
+      'Shake 45 ml rum, 20 ml lime, 15 ml orgeat, 10 ml triple sec. Strain over crushed ice.'
+  },
+  {
+    name: 'Clover Club',
+    ingredients: ['Gin', 'Lemon juice', 'Grenadine'],
+    instructions:
+      'Shake 45 ml gin, 20 ml lemon, 10 ml grenadine with ice. Strain into coupe.'
+  },
+  {
+    name: 'Pink Sunset',
+    ingredients: ['Coconut rum', 'Cranberry juice', 'Pineapple juice'],
+    instructions:
+      'Shake 45 ml coconut rum, 60 ml cranberry, 60 ml pineapple. Strain.'
+  },
+  {
+    name: 'Citrus Sparkler',
+    ingredients: ['Gin', 'Orange juice', 'Sparkling water', 'Bitters'],
+    instructions:
+      'Build with 45 ml gin, 60 ml OJ, dash of bitters, top 100 ml sparkling water.'
+  },
+  {
+    name: 'Mimosa',
+    ingredients: ['Orange juice', 'Prosecco'],
+    instructions: 'Combine equal parts (60 ml each) orange juice and prosecco in flute. No ice.'
+  }
+];
+
+module.exports = {
+  baseIngredients,
+  baseDrinks
+};
+

--- a/server.js
+++ b/server.js
@@ -1,0 +1,331 @@
+const express = require('express');
+const path = require('path');
+const cors = require('cors');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+const app = express();
+const PORT = process.env.PORT || 1933;
+const dataDir = path.join(__dirname, 'data');
+const dbPath = path.join(dataDir, 'cabinet.db');
+
+fs.mkdirSync(dataDir, { recursive: true });
+
+const db = new Database(dbPath);
+db.pragma('foreign_keys = ON');
+
+const { baseDrinks, baseIngredients } = require('./seed/defaultData');
+
+const SEED_VERSION = 1;
+
+
+function migrate() {
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS ingredients (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      category TEXT,
+      in_stock INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS drinks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      instructions TEXT NOT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS drink_ingredients (
+      drink_id INTEGER NOT NULL,
+      ingredient_id INTEGER NOT NULL,
+      PRIMARY KEY (drink_id, ingredient_id),
+      FOREIGN KEY (drink_id) REFERENCES drinks(id) ON DELETE CASCADE,
+      FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE CASCADE
+    )
+  `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS app_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `).run();
+}
+
+function seedIngredients() {
+  const insert = db.prepare('INSERT OR IGNORE INTO ingredients (name, category) VALUES (?, ?)');
+  const updateCategory = db.prepare('UPDATE ingredients SET category = COALESCE(category, ?) WHERE name = ?');
+  const transaction = db.transaction(() => {
+    for (const item of baseIngredients) {
+      insert.run(item.name, item.category);
+      updateCategory.run(item.category, item.name);
+    }
+  });
+  transaction();
+}
+
+function seedDrinks() {
+  const insertDrink = db.prepare('INSERT OR IGNORE INTO drinks (name, instructions) VALUES (?, ?)');
+  const getDrinkId = db.prepare('SELECT id FROM drinks WHERE name = ?');
+  const getIngredientId = db.prepare('SELECT id FROM ingredients WHERE LOWER(name) = LOWER(?)');
+  const insertLink = db.prepare('INSERT OR IGNORE INTO drink_ingredients (drink_id, ingredient_id) VALUES (?, ?)');
+
+  const transaction = db.transaction(() => {
+    for (const drink of baseDrinks) {
+      insertDrink.run(drink.name, drink.instructions);
+      const drinkRow = getDrinkId.get(drink.name);
+      if (!drinkRow) continue;
+      for (const ingredient of drink.ingredients) {
+        const ingredientRow = getIngredientId.get(ingredient);
+        if (!ingredientRow) continue;
+        insertLink.run(drinkRow.id, ingredientRow.id);
+      }
+    }
+  });
+  transaction();
+}
+
+function seedDatabaseIfNeeded() {
+  const getSeedVersionStatement = db.prepare('SELECT value FROM app_meta WHERE key = ?');
+  const upsertSeedVersionStatement = db.prepare(
+    'INSERT INTO app_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+  );
+
+  const row = getSeedVersionStatement.get('seed_version');
+  const parsed = row ? Number.parseInt(row.value, 10) : 0;
+  const currentVersion = Number.isFinite(parsed) ? parsed : 0;
+  if (currentVersion >= SEED_VERSION) {
+    return;
+  }
+
+  seedIngredients();
+  seedDrinks();
+  upsertSeedVersionStatement.run('seed_version', String(SEED_VERSION));
+}
+
+migrate();
+seedDatabaseIfNeeded();
+
+app.use(cors());
+app.use(express.json());
+app.use(express.static(__dirname));
+
+function normaliseIngredientName(name) {
+  return name.trim().replace(/\s+/g, ' ');
+}
+
+function validateDrinkPayload(payload = {}) {
+  const errors = [];
+  const name = typeof payload.name === 'string' ? normaliseIngredientName(payload.name) : '';
+  if (!name) {
+    errors.push('Drink name is required.');
+  }
+
+  const instructions = typeof payload.instructions === 'string' ? payload.instructions.trim() : '';
+  if (!instructions) {
+    errors.push('Instructions are required.');
+  }
+
+  const rawIngredients = Array.isArray(payload.ingredients) ? payload.ingredients : [];
+  const seen = new Set();
+  const ingredients = [];
+
+  for (const value of rawIngredients) {
+    if (typeof value !== 'string') continue;
+    const cleaned = normaliseIngredientName(value);
+    if (!cleaned) continue;
+    const key = cleaned.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ingredients.push(cleaned);
+  }
+
+  if (ingredients.length === 0) {
+    errors.push('At least one ingredient is required.');
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    data: errors.length === 0 ? { name, instructions, ingredients } : null
+  };
+}
+
+const selectIngredientByName = db.prepare(
+  'SELECT id, name, category, in_stock as inStock FROM ingredients WHERE LOWER(name) = LOWER(?)'
+);
+const insertIngredient = db.prepare('INSERT INTO ingredients (name, category, in_stock) VALUES (?, ?, 0)');
+const updateIngredientCategory = db.prepare('UPDATE ingredients SET category = ? WHERE id = ?');
+
+function ensureIngredient(name, { category = null } = {}) {
+  const cleanedName = normaliseIngredientName(name);
+  if (!cleanedName) {
+    throw new Error('Ingredient name is required.');
+  }
+
+  const cleanedCategory = category && typeof category === 'string' ? normaliseIngredientName(category) : null;
+
+  let ingredient = selectIngredientByName.get(cleanedName);
+  if (ingredient) {
+    const currentCategory = ingredient.category || null;
+    if (
+      cleanedCategory &&
+      (!currentCategory || currentCategory.toLowerCase() !== cleanedCategory.toLowerCase())
+    ) {
+      updateIngredientCategory.run(cleanedCategory, ingredient.id);
+      ingredient = { ...ingredient, category: cleanedCategory };
+    }
+    return { ...ingredient, inStock: !!ingredient.inStock };
+  }
+
+  const insertResult = insertIngredient.run(cleanedName, cleanedCategory);
+  return {
+    id: insertResult.lastInsertRowid,
+    name: cleanedName,
+    category: cleanedCategory,
+    inStock: false
+  };
+}
+
+const selectDrinkById = db.prepare('SELECT id, name, instructions FROM drinks WHERE id = ?');
+const selectDrinkIngredients = db.prepare(`
+  SELECT i.id, i.name, i.category, i.in_stock as inStock
+  FROM drink_ingredients di
+  JOIN ingredients i ON i.id = di.ingredient_id
+  WHERE di.drink_id = ?
+  ORDER BY i.name COLLATE NOCASE
+`);
+
+function getDrinkWithAvailability(drinkId) {
+  const drink = selectDrinkById.get(drinkId);
+  if (!drink) return null;
+
+  const ingredients = selectDrinkIngredients.all(drinkId).map((row) => ({
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    inStock: !!row.inStock
+  }));
+
+  const total = ingredients.length;
+  const available = ingredients.filter((item) => item.inStock).length;
+  const missing = ingredients.filter((item) => !item.inStock);
+
+  return {
+    id: drink.id,
+    name: drink.name,
+    instructions: drink.instructions,
+    ingredients,
+    availability: {
+      total,
+      available,
+      missing: missing.map((item) => item.name)
+    }
+  };
+}
+
+app.get('/api/ingredients', (req, res) => {
+  const ingredients = db
+    .prepare('SELECT id, name, category, in_stock as inStock FROM ingredients ORDER BY name COLLATE NOCASE')
+    .all();
+  res.json(ingredients);
+});
+
+app.post('/api/ingredients', (req, res) => {
+  const { name, category = null, inStock = false } = req.body || {};
+  if (!name || typeof name !== 'string') {
+    return res.status(400).json({ message: 'Ingredient name is required.' });
+  }
+  const cleanName = normaliseIngredientName(name);
+  const categoryValue = category && typeof category === 'string' ? normaliseIngredientName(category) : null;
+  const insert = db.prepare(
+    'INSERT INTO ingredients (name, category, in_stock) VALUES (?, ?, ?) ON CONFLICT(name) DO UPDATE SET category = COALESCE(excluded.category, ingredients.category)'
+  );
+  const result = insert.run(cleanName, categoryValue, inStock ? 1 : 0);
+  const ingredient = db
+    .prepare('SELECT id, name, category, in_stock as inStock FROM ingredients WHERE name = ?')
+    .get(cleanName);
+  res.status(result.changes ? 201 : 200).json(ingredient);
+});
+
+app.patch('/api/ingredients/:id', (req, res) => {
+  const { id } = req.params;
+  const { inStock } = req.body || {};
+  if (typeof inStock !== 'boolean') {
+    return res.status(400).json({ message: 'inStock must be a boolean.' });
+  }
+  const update = db.prepare('UPDATE ingredients SET in_stock = ? WHERE id = ?');
+  const result = update.run(inStock ? 1 : 0, id);
+  if (result.changes === 0) {
+    return res.status(404).json({ message: 'Ingredient not found.' });
+  }
+  const ingredient = db
+    .prepare('SELECT id, name, category, in_stock as inStock FROM ingredients WHERE id = ?')
+    .get(id);
+  res.json(ingredient);
+});
+
+app.post('/api/ingredients/reset', (req, res) => {
+  db.prepare('UPDATE ingredients SET in_stock = 0').run();
+  const ingredients = db
+    .prepare('SELECT id, name, category, in_stock as inStock FROM ingredients ORDER BY name COLLATE NOCASE')
+    .all();
+  res.json(ingredients);
+});
+
+app.get('/api/drinks', (req, res) => {
+  const drinks = db.prepare('SELECT id FROM drinks ORDER BY name COLLATE NOCASE').all();
+  const payload = drinks
+    .map((row) => getDrinkWithAvailability(row.id))
+    .filter((drink) => drink !== null);
+  res.json(payload);
+});
+
+const insertDrinkStatement = db.prepare('INSERT INTO drinks (name, instructions) VALUES (?, ?)');
+const linkIngredientStatement = db.prepare('INSERT INTO drink_ingredients (drink_id, ingredient_id) VALUES (?, ?)');
+
+app.post('/api/drinks', (req, res, next) => {
+  const validation = validateDrinkPayload(req.body);
+  if (!validation.ok) {
+    return res.status(400).json({ message: validation.errors[0], errors: validation.errors });
+  }
+
+  const { name, instructions, ingredients } = validation.data;
+
+  try {
+    const createDrink = db.transaction(() => {
+      const result = insertDrinkStatement.run(name, instructions);
+      const drinkId = result.lastInsertRowid;
+
+      for (const ingredientName of ingredients) {
+        const ingredient = ensureIngredient(ingredientName);
+        linkIngredientStatement.run(drinkId, ingredient.id);
+      }
+
+      return drinkId;
+    });
+
+    const drinkId = createDrink();
+    const payload = getDrinkWithAvailability(drinkId);
+    res.status(201).json(payload);
+  } catch (error) {
+    if (error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      return res.status(409).json({ message: 'A drink with that name already exists.' });
+    }
+    next(error);
+  }
+});
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ message: 'Unexpected server error.' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Drink cabinet API listening on http://localhost:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,434 @@
+:root {
+  color-scheme: light;
+  font-family: "Work Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #faf7f2;
+  color: #1f1b16;
+  --accent: #f97316;
+  --accent-muted: #fed7aa;
+  --card-bg: #ffffffcc;
+  --card-border: #e2d5c3;
+  --pill-bg: #f1e4d3;
+  --pill-text: #312517;
+  --shadow: 0 18px 35px rgba(87, 57, 36, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-image: radial-gradient(circle at top, rgba(255, 255, 255, 0.7), rgba(255, 237, 213, 0.6));
+}
+
+.app-header {
+  text-align: center;
+  padding: 3rem 1.5rem 2rem;
+  background: linear-gradient(180deg, rgba(255, 244, 230, 0.9), rgba(255, 249, 244, 0));
+}
+
+.app-header h1 {
+  margin: 0;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: clamp(2.25rem, 3vw + 1rem, 3.6rem);
+  letter-spacing: 0.03em;
+}
+
+.tagline {
+  margin-top: 0.75rem;
+  font-size: 1.05rem;
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+  color: #5f4b3c;
+}
+
+.app-layout {
+  display: grid;
+  gap: 2rem;
+  padding: 0 1.5rem 3rem;
+  max-width: 1100px;
+  margin: 0 auto 3rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+}
+
+.section-header h2 {
+  margin: 0;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1.85rem;
+}
+
+.section-header p {
+  margin: 0.35rem 0 1.5rem;
+  color: #6c5b4b;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: end;
+}
+
+.form-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.stacked-form {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-control {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 500;
+  color: #3c2f24;
+}
+
+.field-help {
+  margin: 0;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: #7c6a58;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  padding: 0.7rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid #d8c6b5;
+  background: rgba(255, 255, 255, 0.92);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ingredient-selector {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.selected-ingredients {
+  list-style: none;
+  padding: 0.35rem;
+  margin: 0;
+  min-height: 48px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border: 1px dashed rgba(216, 198, 181, 0.9);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.selector-empty {
+  color: #9f8774;
+  font-weight: 400;
+  font-size: 0.9rem;
+}
+
+.selector-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+#drink-ingredient-search {
+  flex: 1;
+}
+
+.secondary-btn {
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #e7c9aa;
+  background: rgba(255, 255, 255, 0.95);
+  color: #9a4d1e;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.secondary-btn:hover {
+  background: #fef3c7;
+  color: #a16207;
+  box-shadow: 0 6px 14px rgba(209, 134, 32, 0.2);
+}
+
+.secondary-btn:focus-visible {
+  outline: 3px solid var(--accent-muted);
+  outline-offset: 2px;
+}
+
+.selector-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--pill-bg);
+  color: var(--pill-text);
+  font-weight: 500;
+}
+
+.selector-pill .remove-pill {
+  border: none;
+  background: none;
+  color: #9a4d1e;
+  font-weight: 600;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.selector-pill .remove-pill:focus-visible {
+  outline: 2px solid var(--accent);
+  border-radius: 999px;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.2);
+}
+
+.primary-btn {
+  justify-self: start;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), #ea580c);
+  color: white;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(234, 88, 12, 0.35);
+}
+
+.primary-btn:focus-visible {
+  outline: 3px solid var(--accent-muted);
+  outline-offset: 2px;
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: #d97706;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.link-btn:hover {
+  text-decoration: underline;
+}
+
+.inventory-controls {
+  margin: 1.5rem 0 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #5f4b3c;
+}
+
+.pill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: var(--pill-bg);
+  color: var(--pill-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.pill button {
+  border: none;
+  background: none;
+  color: #9a4d1e;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.drinks-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.chip {
+  border: 1px solid #e7c9aa;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 999px;
+  padding: 0.4rem 0.95rem;
+  cursor: pointer;
+  font-weight: 500;
+  color: #6b4e32;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.chip-active,
+.chip:hover {
+  background: #fef3c7;
+  color: #a16207;
+}
+
+.drinks-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.empty-state {
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(224, 178, 122, 0.7);
+  background: rgba(255, 247, 237, 0.8);
+  color: #a16207;
+  font-weight: 500;
+  text-align: center;
+}
+
+.drink-card {
+  border: 1px solid rgba(231, 208, 182, 0.8);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.85);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.drink-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.drink-title {
+  margin: 0;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1.35rem;
+}
+
+.drink-status {
+  margin: 0.3rem 0 0;
+  color: #7c5f45;
+  font-weight: 500;
+}
+
+.drink-badge {
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.drink-badge.badge-ready {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.drink-badge.badge-partial {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.drink-badge.badge-missing {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.drink-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #8c6844;
+}
+
+.drink-details summary::marker {
+  color: #d97706;
+}
+
+.ingredient-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.ingredient-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+}
+
+.ingredient-list li.ingredient-ready {
+  background: #f0fdf4;
+  color: #14532d;
+}
+
+.ingredient-list li.ingredient-missing {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.missing-ingredients {
+  margin: 0 0 0.75rem;
+  color: #92400e;
+  font-weight: 500;
+}
+
+@media (min-width: 900px) {
+  .app-layout {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding-top: 2.5rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an app_meta table and seed version constant so the server can track bundled dataset revisions
- gate seed execution behind the stored version and reuse the existing routines when a new bundle ships
- update the README to describe the version-based seeding behaviour

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e3702b72dc832686441c62c38d7870