### PR TITLE
Fix duplicate drink endpoints and clean front-end state handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@ const state = {
   filter: 'all',
   searchTerm: '',
   drinkFormIngredients: []
-  filter: 'all'
 };
 
 const elements = {
@@ -56,6 +55,8 @@ async function loadDrinks() {
 }
 
 function updateIngredientCatalog() {
+  if (!elements.ingredientCatalog || !elements.drinkIngredientCatalog) return;
+
   elements.ingredientCatalog.innerHTML = '';
   elements.drinkIngredientCatalog.innerHTML = '';
   const sorted = [...state.ingredients].sort((a, b) => a.name.localeCompare(b.name));
@@ -119,6 +120,8 @@ function renderIngredientPill(ingredient) {
 }
 
 function renderIngredients() {
+  if (!elements.inventoryCount || !elements.ingredientList) return;
+
   const inStockCount = state.ingredients.filter((item) => item.inStock).length;
   if (state.ingredients.length === 0) {
     elements.inventoryCount.textContent = 'No ingredients saved yet.';
@@ -149,7 +152,7 @@ function normaliseIngredientInput(name) {
 }
 
 function resolveIngredientName(value) {
-  const cleanValue = normaliseIngredientInput(value);
+  const cleanValue = normaliseIngredientInput(value || '');
   if (!cleanValue) return '';
   const existing = state.ingredients.find((item) => item.name.toLowerCase() === cleanValue.toLowerCase());
   return existing ? existing.name : cleanValue;
@@ -157,6 +160,8 @@ function resolveIngredientName(value) {
 
 function renderSelectedDrinkIngredients() {
   const list = elements.selectedDrinkIngredients;
+  if (!list) return;
+
   list.innerHTML = '';
 
   if (state.drinkFormIngredients.length === 0) {
@@ -187,8 +192,10 @@ function renderSelectedDrinkIngredients() {
 }
 
 function updateDrinkFormState() {
-  elements.drinkIngredients.value = state.drinkFormIngredients.join(', ');
-  if (state.drinkFormIngredients.length > 0) {
+  if (elements.drinkIngredients) {
+    elements.drinkIngredients.value = state.drinkFormIngredients.join(', ');
+  }
+  if (elements.drinkIngredientSearch && state.drinkFormIngredients.length > 0) {
     elements.drinkIngredientSearch.setCustomValidity('');
   }
 }
@@ -196,6 +203,9 @@ function updateDrinkFormState() {
 function addDrinkIngredient(rawValue) {
   const resolvedName = resolveIngredientName(rawValue || '');
   if (!resolvedName) {
+    if (elements.drinkIngredientSearch) {
+      elements.drinkIngredientSearch.value = '';
+    }
     return;
   }
 
@@ -203,15 +213,19 @@ function addDrinkIngredient(rawValue) {
     (item) => item.toLowerCase() === resolvedName.toLowerCase()
   );
   if (exists) {
-    elements.drinkIngredientSearch.value = '';
+    if (elements.drinkIngredientSearch) {
+      elements.drinkIngredientSearch.value = '';
+    }
     return;
   }
 
   state.drinkFormIngredients.push(resolvedName);
   renderSelectedDrinkIngredients();
   updateDrinkFormState();
-  elements.drinkIngredientSearch.value = '';
-  elements.drinkIngredientSearch.focus();
+  if (elements.drinkIngredientSearch) {
+    elements.drinkIngredientSearch.value = '';
+    elements.drinkIngredientSearch.focus();
+  }
 }
 
 function removeDrinkIngredient(index) {
@@ -225,8 +239,13 @@ function removeDrinkIngredient(index) {
 
 function resetDrinkForm() {
   state.drinkFormIngredients = [];
-  elements.drinkForm.reset();
-  elements.drinkIngredientSearch.value = '';
+  if (elements.drinkForm) {
+    elements.drinkForm.reset();
+  }
+  if (elements.drinkIngredientSearch) {
+    elements.drinkIngredientSearch.value = '';
+    elements.drinkIngredientSearch.setCustomValidity('');
+  }
   renderSelectedDrinkIngredients();
   updateDrinkFormState();
 }
@@ -291,7 +310,10 @@ function shouldDisplayDrink(drink) {
 }
 
 function renderDrinkCard(drink) {
-  const node = elements.drinkTemplate.content.cloneNode(true);
+  const template = elements.drinkTemplate;
+  if (!template) return document.createDocumentFragment();
+
+  const node = template.content.cloneNode(true);
   const listItem = node.querySelector('.drink-card');
   listItem.dataset.drinkId = drink.id;
 
@@ -321,11 +343,7 @@ function renderDrinkCard(drink) {
   for (const ingredient of drink.ingredients) {
     const ingredientItem = document.createElement('li');
     ingredientItem.textContent = ingredient.name;
-    if (ingredient.inStock) {
-      ingredientItem.classList.add('ingredient-ready');
-    } else {
-      ingredientItem.classList.add('ingredient-missing');
-    }
+    ingredientItem.classList.add(ingredient.inStock ? 'ingredient-ready' : 'ingredient-missing');
     ingredientList.append(ingredientItem);
   }
 
@@ -340,6 +358,8 @@ function renderDrinkCard(drink) {
 }
 
 function renderDrinks() {
+  if (!elements.drinksList) return;
+
   elements.drinksList.innerHTML = '';
   if (state.drinks.length === 0) {
     const empty = document.createElement('li');
@@ -356,69 +376,19 @@ function renderDrinks() {
     const trimmedSearch = state.searchTerm.trim();
     if (trimmedSearch) {
       empty.textContent = `No drinks match "${trimmedSearch}". Try a different name or ingredient.`;
+    } else if (state.filter === 'ready') {
+      empty.textContent = 'Nothing is fully stocked yet. Add more ingredients to unlock drinks.';
+    } else if (state.filter === 'missing') {
+      empty.textContent = 'Everything here is ready to shake. Switch filters to explore more.';
     } else {
-      empty.textContent =
-        state.filter === 'ready'
-          ? 'Nothing is fully stocked yet. Add more ingredients to unlock drinks.'
-          : 'Everything here is ready to shake. Switch filters to explore more.';
+      empty.textContent = 'No drinks to display.';
     }
-    empty.textContent =
-      state.filter === 'ready'
-        ? 'Nothing is fully stocked yet. Add more ingredients to unlock drinks.'
-        : 'Everything here is ready to shake. Switch filters to explore more.';
     elements.drinksList.append(empty);
     return;
   }
 
   for (const drink of drinksToShow) {
     elements.drinksList.append(renderDrinkCard(drink));
-  const template = elements.drinkTemplate.content;
-  for (const drink of drinksToShow) {
-    const summary = summariseDrink(drink);
-    const node = template.cloneNode(true);
-    const listItem = node.querySelector('.drink-card');
-    listItem.dataset.drinkId = drink.id;
-
-    node.querySelector('.drink-title').textContent = drink.name;
-    node.querySelector('.drink-recipe').textContent = drink.instructions;
-
-    const status = node.querySelector('.drink-status');
-    const badge = node.querySelector('.drink-badge');
-    if (summary.ready) {
-      status.textContent = 'Ready to mix';
-      badge.textContent = 'Ready';
-      badge.className = 'drink-badge badge-ready';
-    } else if (summary.missing.length === summary.total) {
-      status.textContent = 'Missing every ingredient';
-      badge.textContent = 'Out';
-      badge.className = 'drink-badge badge-missing';
-    } else {
-      status.textContent = `Missing ${summary.missing.length} of ${summary.total}`;
-      badge.textContent = `${summary.available}/${summary.total}`;
-      badge.className = 'drink-badge badge-partial';
-    }
-
-    const ingredientList = node.querySelector('.ingredient-list');
-    ingredientList.innerHTML = '';
-    for (const ingredient of drink.ingredients) {
-      const ingredientItem = document.createElement('li');
-      ingredientItem.textContent = ingredient.name;
-      if (ingredient.inStock) {
-        ingredientItem.classList.add('ingredient-ready');
-      } else {
-        ingredientItem.classList.add('ingredient-missing');
-      }
-      ingredientList.append(ingredientItem);
-    }
-
-    const missingText = node.querySelector('.missing-ingredients');
-    if (summary.missing.length > 0) {
-      missingText.textContent = `Missing: ${summary.missing.map((item) => item.name).join(', ')}`;
-    } else {
-      missingText.textContent = 'Everything you need is on hand.';
-    }
-
-    elements.drinksList.append(node);
   }
 }
 
@@ -438,8 +408,8 @@ async function toggleIngredient(id, inStock) {
 
 async function handleIngredientSubmit(event) {
   event.preventDefault();
-  const name = elements.ingredientName.value.trim();
-  const category = elements.ingredientCategory.value.trim();
+  const name = elements.ingredientName?.value.trim();
+  const category = elements.ingredientCategory?.value.trim();
   if (!name) return;
 
   try {
@@ -448,7 +418,9 @@ async function handleIngredientSubmit(event) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, category: category || null, inStock: true })
     });
-    elements.ingredientForm.reset();
+    if (elements.ingredientForm) {
+      elements.ingredientForm.reset();
+    }
     await loadIngredients();
   } catch (error) {
     console.error(error);
@@ -468,24 +440,21 @@ async function handleResetInventory() {
 
 async function handleDrinkSubmit(event) {
   event.preventDefault();
-  elements.drinkIngredientSearch.setCustomValidity('');
-  const name = elements.drinkName.value.trim();
-  const instructions = elements.drinkRecipe.value.trim();
+  if (elements.drinkIngredientSearch) {
+    elements.drinkIngredientSearch.setCustomValidity('');
+  }
+
+  const name = elements.drinkName?.value.trim();
+  const instructions = elements.drinkRecipe?.value.trim();
   const ingredientsInput = state.drinkFormIngredients.map((value) => value.trim()).filter(Boolean);
 
   if (!name || !instructions || ingredientsInput.length === 0) {
-    if (ingredientsInput.length === 0) {
+    if (ingredientsInput.length === 0 && elements.drinkIngredientSearch) {
       elements.drinkIngredientSearch.setCustomValidity('Add at least one ingredient to the drink.');
       elements.drinkIngredientSearch.reportValidity();
+    } else if (elements.drinkForm) {
+      elements.drinkForm.reportValidity();
     }
-  const name = elements.drinkName.value.trim();
-  const instructions = elements.drinkRecipe.value.trim();
-  const ingredientsInput = elements.drinkIngredients.value
-    .split(',')
-    .map((value) => value.trim())
-    .filter(Boolean);
-
-  if (!name || !instructions || ingredientsInput.length === 0) {
     return;
   }
 
@@ -496,7 +465,6 @@ async function handleDrinkSubmit(event) {
       body: JSON.stringify({ name, instructions, ingredients: ingredientsInput })
     });
     resetDrinkForm();
-    elements.drinkForm.reset();
     await Promise.all([loadDrinks(), loadIngredients()]);
   } catch (error) {
     console.error(error);
@@ -539,24 +507,21 @@ function handleSelectedIngredientClick(event) {
 }
 
 function handleAddIngredientButton() {
-  addDrinkIngredient(elements.drinkIngredientSearch.value);
+  if (elements.drinkIngredientSearch) {
+    addDrinkIngredient(elements.drinkIngredientSearch.value);
+  }
 }
 
 function setupEventListeners() {
-  elements.ingredientForm.addEventListener('submit', handleIngredientSubmit);
-  elements.resetInventory.addEventListener('click', handleResetInventory);
-  elements.drinkForm.addEventListener('submit', handleDrinkSubmit);
-  if (elements.filterGroup) {
-    elements.filterGroup.addEventListener('click', handleFilterClick);
-  }
-  if (elements.drinkSearch) {
-    elements.drinkSearch.addEventListener('input', handleDrinkSearchInput);
-  }
-  elements.drinkIngredientSearch.addEventListener('change', handleDrinkIngredientSelection);
-  elements.drinkIngredientSearch.addEventListener('keydown', handleDrinkIngredientKeydown);
-  elements.selectedDrinkIngredients.addEventListener('click', handleSelectedIngredientClick);
-  elements.addIngredientToDrink.addEventListener('click', handleAddIngredientButton);
-  document.querySelector('.drinks-filter').addEventListener('click', handleFilterClick);
+  elements.ingredientForm?.addEventListener('submit', handleIngredientSubmit);
+  elements.resetInventory?.addEventListener('click', handleResetInventory);
+  elements.drinkForm?.addEventListener('submit', handleDrinkSubmit);
+  elements.filterGroup?.addEventListener('click', handleFilterClick);
+  elements.drinkSearch?.addEventListener('input', handleDrinkSearchInput);
+  elements.drinkIngredientSearch?.addEventListener('change', handleDrinkIngredientSelection);
+  elements.drinkIngredientSearch?.addEventListener('keydown', handleDrinkIngredientKeydown);
+  elements.selectedDrinkIngredients?.addEventListener('click', handleSelectedIngredientClick);
+  elements.addIngredientToDrink?.addEventListener('click', handleAddIngredientButton);
 }
 
 async function bootstrap() {

--- a/index.html
+++ b/index.html
@@ -83,10 +83,6 @@
           </label>
         </div>
         <datalist id="drink-ingredient-catalog"></datalist>
-            <span>Ingredients <small>(separate with commas)</small></span>
-            <input type="text" id="drink-ingredients" placeholder="Gin, Lemon juice, Simple syrup" required />
-          </label>
-        </div>
         <label class="form-control">
           <span>Recipe / Instructions</span>
           <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>
@@ -109,11 +105,6 @@
           <button type="button" data-filter="ready" class="chip">Ready to mix</button>
           <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
         </div>
-      <div class="drinks-filter" role="group" aria-label="Filter drinks">
-        <button type="button" data-filter="all" class="chip chip-active">All drinks</button>
-        <button type="button" data-filter="ready" class="chip">Ready to mix</button>
-        <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
-      </div>
 
       <ul id="drinks-list" class="drinks-list" aria-live="polite"></ul>
     </section>


### PR DESCRIPTION
## Summary
- remove the duplicate drink creation implementations and handle name conflicts in the API
- simplify the client state management to prevent duplicate UI handlers and keep ingredient selectors in sync
- clean up the cocktail form markup so only the enhanced ingredient selector is rendered

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e39aff5100832695dc2e0087083fff