### PR TITLE
Group inventory by category and restore drink layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <button type="button" id="reset-inventory" class="link-btn">Clear all</button>
       </div>
 
-      <ul id="inventory-list" class="pill-list" aria-live="polite"></ul>
+      <div id="inventory-list" class="ingredient-groups" aria-live="polite"></div>
     </section>
 
     <section class="card" aria-labelledby="drinks-heading">
@@ -83,10 +83,6 @@
           </label>
         </div>
         <datalist id="drink-ingredient-catalog"></datalist>
-            <span>Ingredients <small>(separate with commas)</small></span>
-            <input type="text" id="drink-ingredients" placeholder="Gin, Lemon juice, Simple syrup" required />
-          </label>
-        </div>
         <label class="form-control">
           <span>Recipe / Instructions</span>
           <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>
@@ -109,11 +105,6 @@
           <button type="button" data-filter="ready" class="chip">Ready to mix</button>
           <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
         </div>
-      <div class="drinks-filter" role="group" aria-label="Filter drinks">
-        <button type="button" data-filter="all" class="chip chip-active">All drinks</button>
-        <button type="button" data-filter="ready" class="chip">Ready to mix</button>
-        <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
-      </div>
 
       <ul id="drinks-list" class="drinks-list" aria-live="polite"></ul>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -282,6 +282,8 @@ textarea:focus {
   align-items: center;
   gap: 0.5rem;
   font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .pill button {
@@ -290,6 +292,44 @@ textarea:focus {
   color: #9a4d1e;
   font-weight: 600;
   cursor: pointer;
+}
+
+.pill:focus-visible {
+  outline: 3px solid var(--accent-muted);
+  outline-offset: 2px;
+}
+
+.pill-active {
+  background: #dcfce7;
+  color: #166534;
+  box-shadow: 0 6px 16px rgba(22, 101, 52, 0.18);
+}
+
+.pill-active:hover {
+  background: #bbf7d0;
+}
+
+.ingredient-groups {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.ingredient-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.ingredient-group-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8c6a49;
+}
+
+.ingredient-group-list {
+  margin-top: 0.25rem;
 }
 
 .drink-toolbar {
@@ -329,11 +369,6 @@ textarea:focus {
   gap: 0.5rem;
   justify-content: flex-end;
   margin: 0;
-.drinks-filter {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
 }
 
 .chip {


### PR DESCRIPTION
## Summary
- group stored ingredients under their categories and highlight stocked items in green
- normalise ingredient data and accessibility state when toggling availability
- fix the drinks filter styles so the cocktail cards align with the rest of the layout

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e39aff5100832695dc2e0087083fff