### PR TITLE
Fix drinks list width within cocktail library card

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
           <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
         </div>
 
+      </div>
       <ul id="drinks-list" class="drinks-list" aria-live="polite"></ul>
     </section>
   </main>

--- a/styles.css
+++ b/styles.css
@@ -408,6 +408,7 @@ textarea:focus {
   margin: 0;
   display: grid;
   gap: 1rem;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .modal {


### PR DESCRIPTION
## Summary
- close the drink toolbar div before rendering the drinks list so it is no longer constrained by the flex layout
- ensure the drinks list spans the full width of the cocktail library card across all filters

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68e40920fc04832698adb3093248e626