### PR TITLE
Make drinks list scroll within fixed-height card

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,9 +128,10 @@
           <button type="button" data-filter="ready" class="chip">Ready to mix</button>
           <button type="button" data-filter="missing" class="chip">Missing ingredients</button>
         </div>
-
       </div>
-      <ul id="drinks-list" class="drinks-list" aria-live="polite"></ul>
+      <div class="drinks-scroll-area">
+        <ul id="drinks-list" class="drinks-list" aria-live="polite"></ul>
+      </div>
     </section>
   </main>
 

--- a/layout-sync.js
+++ b/layout-sync.js
@@ -2,30 +2,8 @@ let initialized = false;
 let frameId = null;
 let fridgeCard = null;
 let drinksCard = null;
-let drinksList = null;
 let drinksScrollArea = null;
 let layoutMediaQuery = null;
-
-function ensureDrinksScrollArea(list) {
-  if (!list) {
-    return null;
-  }
-
-  const parent = list.parentElement;
-  if (!parent) {
-    return null;
-  }
-
-  if (parent.classList.contains('drinks-scroll-area')) {
-    return parent;
-  }
-
-  const wrapper = document.createElement('div');
-  wrapper.className = 'drinks-scroll-area';
-  parent.insertBefore(wrapper, list);
-  wrapper.appendChild(list);
-  return wrapper;
-}
 
 function calculateNonScrollableHeight() {
   if (!drinksCard || !drinksScrollArea) {
@@ -87,15 +65,14 @@ export function initializeLayoutSync() {
     return;
   }
 
-  drinksList = document.getElementById('drinks-list');
-  drinksCard = drinksList?.closest('.drinks-card') ?? null;
+  drinksCard = document.querySelector('.drinks-card');
   fridgeCard = document.querySelector('.fridge-card');
 
-  if (!drinksList || !drinksCard || !fridgeCard) {
+  if (!drinksCard || !fridgeCard) {
     return;
   }
 
-  drinksScrollArea = ensureDrinksScrollArea(drinksList);
+  drinksScrollArea = drinksCard.querySelector('.drinks-scroll-area');
   if (!drinksScrollArea) {
     return;
   }


### PR DESCRIPTION
## Summary
- wrap the cocktail list in a dedicated scroll container so the add-drink form remains fixed
- simplify the layout sync helper to size the scroll area based on the new markup

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e54754e1088326b84efd4d305bac93