### PR TITLE
Add delete functionality for ingredients and drinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,11 +193,21 @@
   <template id="drink-template">
     <li class="drink-card">
       <header class="drink-header">
-        <div>
+        <div class="drink-header-info">
           <h3 class="drink-title"></h3>
           <p class="drink-status"></p>
         </div>
-        <span class="drink-badge" aria-hidden="true"></span>
+        <div class="drink-header-actions">
+          <span class="drink-badge" aria-hidden="true"></span>
+          <button
+            type="button"
+            class="icon-btn drink-delete-btn"
+            data-action="delete-drink"
+            aria-label="Delete drink"
+          >
+            ×
+          </button>
+        </div>
       </header>
       <details class="drink-details">
         <summary>

--- a/server.js
+++ b/server.js
@@ -288,6 +288,8 @@ app.get('/api/drinks', (req, res) => {
 
 const insertDrinkStatement = db.prepare('INSERT INTO drinks (name, instructions) VALUES (?, ?)');
 const linkIngredientStatement = db.prepare('INSERT INTO drink_ingredients (drink_id, ingredient_id) VALUES (?, ?)');
+const deleteIngredientStatement = db.prepare('DELETE FROM ingredients WHERE id = ?');
+const deleteDrinkStatement = db.prepare('DELETE FROM drinks WHERE id = ?');
 
 app.post('/api/drinks', (req, res, next) => {
   const validation = validateDrinkPayload(req.body);
@@ -319,6 +321,24 @@ app.post('/api/drinks', (req, res, next) => {
     }
     next(error);
   }
+});
+
+app.delete('/api/ingredients/:id', (req, res) => {
+  const { id } = req.params;
+  const result = deleteIngredientStatement.run(id);
+  if (result.changes === 0) {
+    return res.status(404).json({ message: 'Ingredient not found.' });
+  }
+  res.status(204).end();
+});
+
+app.delete('/api/drinks/:id', (req, res) => {
+  const { id } = req.params;
+  const result = deleteDrinkStatement.run(id);
+  if (result.changes === 0) {
+    return res.status(404).json({ message: 'Drink not found.' });
+  }
+  res.status(204).end();
 });
 
 app.use((err, req, res, next) => {

--- a/styles.css
+++ b/styles.css
@@ -536,12 +536,42 @@ textarea:focus {
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.pill-label {
+  flex: 1;
+}
+
 .pill button {
   border: none;
   background: none;
   color: var(--secondary-btn-text);
   font-weight: 600;
   cursor: pointer;
+}
+
+.pill-delete {
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.pill-delete:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+:root[data-theme='dark'] .pill-delete:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.pill-delete:focus-visible {
+  outline: 3px solid var(--accent-muted);
+  outline-offset: 1px;
 }
 
 .pill:focus-visible {
@@ -742,6 +772,30 @@ textarea:focus {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+}
+
+.drink-header-info {
+  flex: 1;
+}
+
+.drink-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.drink-delete-btn {
+  font-size: 1.35rem;
+  color: var(--icon-color);
+}
+
+.drink-delete-btn:hover {
+  color: var(--icon-hover-color);
+}
+
+.drink-delete-btn:focus-visible {
+  outline: 3px solid var(--accent-muted);
+  border-radius: 8px;
 }
 
 .drink-title {


### PR DESCRIPTION
## Summary
- add DELETE endpoints for ingredients and drinks to remove records from the SQLite store
- allow users to remove ingredients and drinks from the UI with new delete buttons and confirmation prompts
- adjust client helpers and styling to support the new controls and empty server responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6200d295c83269bdda55a41306e26