### PR TITLE
Replace drink ingredient text entry with dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,23 +89,22 @@
                 aria-label="Selected ingredients"
               ></ul>
               <div class="selector-controls">
-                <input
-                  type="text"
-                  id="drink-ingredient-search"
-                  list="drink-ingredient-catalog"
-                  placeholder="Search ingredients"
+                <select
+                  id="drink-ingredient-select"
                   aria-describedby="drink-ingredient-help"
-                />
+                >
+                  <option value="" disabled selected hidden>Select an ingredient</option>
+                </select>
                 <button type="button" id="add-ingredient-to-drink" class="secondary-btn">Add</button>
               </div>
             </div>
             <p class="field-help" id="drink-ingredient-help">
-              Search your fridge for existing ingredients or type a new one and press Add.
+              Pick from the ingredients already saved in your fridge and press Add.
             </p>
             <input type="hidden" id="drink-ingredients" />
           </label>
         </div>
-        <datalist id="drink-ingredient-catalog"></datalist>
+        
         <label class="form-control">
           <span>Recipe / Instructions</span>
           <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>
@@ -162,23 +161,22 @@
               aria-label="Selected ingredients"
             ></ul>
             <div class="selector-controls">
-              <input
-                type="text"
-                id="drink-ingredient-search"
-                list="drink-ingredient-catalog"
-                placeholder="Search ingredients"
+              <select
+                id="drink-ingredient-select"
                 aria-describedby="drink-ingredient-help"
-              />
+              >
+                <option value="" disabled selected hidden>Select an ingredient</option>
+              </select>
               <button type="button" id="add-ingredient-to-drink" class="secondary-btn">Add</button>
             </div>
           </div>
           <p class="field-help" id="drink-ingredient-help">
-            Search your fridge for existing ingredients or type a new one and press Add.
+            Pick from the ingredients already saved in your fridge and press Add.
           </p>
           <input type="hidden" id="drink-ingredients" />
         </label>
       </div>
-      <datalist id="drink-ingredient-catalog"></datalist>
+      
       <label class="form-control">
         <span>Recipe / Instructions</span>
         <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>


### PR DESCRIPTION
## Summary
- replace the drink ingredient text input with a dropdown that only lists saved fridge and pantry items
- update the client logic to populate and validate the select field while keeping the drink form state in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecac234798832696ffc22958742d14