### PR TITLE
Hide add drink form behind collapsible panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ A cocktail recipe book backed by SQLite that helps you manage your home bar inve
 
 - **Fridge & Pantry module** – add ingredients, tag them by category, and flip them in or out of stock. Everything is stored in a SQLite database so your inventory persists between sessions.
 - **Cocktail library** – browse a curated starter collection of spritzes, highballs, and sours. Every recipe checks against your fridge to highlight what is ready to shake and what still needs a shopping trip.
-- **Custom creations** – add new drinks with a name, searchable ingredient selector (with inline creation), and preparation instructions. Ingredients are automatically linked in the database so availability stays in sync.
+- **Custom creations** – add new drinks with a name, dropdown ingredient selector that only lists items already in your fridge, and preparation instructions. The form lives inside an expandable panel so you can focus on browsing until you need it. Ingredients are automatically linked in the database so availability stays in sync.
 - **Search & filter controls** – find drinks by name, ingredient, or method while toggling between ready-to-mix and missing-ingredient views.
-- **Custom creations** – add new drinks with a name, comma-separated ingredient list, and preparation instructions. Ingredients are automatically linked in the database so availability stays in sync.
 - **Server-side API** – the front end fetches data from a tiny Express API, which you can extend or connect to other clients if needed.
 
 ## Requirements
@@ -28,13 +27,12 @@ A cocktail recipe book backed by SQLite that helps you manage your home bar inve
 3. Open [http://localhost:1933](http://localhost:1933) in your browser. The Express server serves the static front-end files and the JSON API at the same port.
 
 The first start seeds the SQLite database (`data/cabinet.db`) with a base catalogue of ingredients and drinks. Subsequent launches reuse the same file so your additions persist, and seeding only re-runs when the bundled dataset version changes.
-The first start seeds the SQLite database (`data/cabinet.db`) with a base catalogue of ingredients and drinks. Subsequent launches reuse the same file so your additions persist.
 
 ## Development tips
 
 - The API lives in `server.js`. It exposes `/api/ingredients` and `/api/drinks` endpoints for listing, creating, and updating data.
 - Ingredient inventory is toggled with `PATCH /api/ingredients/:id`. Use `POST /api/ingredients/reset` to clear stock flags without removing entries.
-- Drinks created through the UI automatically create missing ingredients in the catalogue (marked out of stock by default) so you can immediately manage them in the fridge module.
+- Add new ingredients from the Fridge & Pantry module first—drink creation now only lets you select items that already exist in your inventory.
 
 To iterate faster while developing, you can run the server with hot reload using `npm run dev` (requires `nodemon`, installed as a dev dependency).
 
@@ -45,8 +43,6 @@ To iterate faster while developing, you can run the server with hot reload using
 - `migrate()` – ensures the SQLite schema for ingredients, drinks, and their join table exists before handling requests.
 - `seedIngredients()` – inserts the starter ingredient catalogue while keeping any user-supplied categories intact (data lives in `seed/defaultData.js`).
 - `seedDrinks()` – loads the base drink recipes from `seed/defaultData.js`, linking them to the corresponding ingredients.
-- `seedIngredients()` – inserts the starter ingredient catalogue while keeping any user-supplied categories intact.
-- `seedDrinks()` – loads the base drink recipes, linking them to the corresponding ingredients.
 - `normaliseIngredientName(name)` – trims and collapses whitespace so ingredient and drink names stay consistent.
 - Express route handlers – serve and mutate ingredient and drink data (`/api/ingredients`, `/api/drinks`) with validation and error handling.
 
@@ -54,8 +50,7 @@ To iterate faster while developing, you can run the server with hot reload using
 
 - `fetchJSON(url, options)` – wraps `fetch` calls, throwing helpful errors when responses fail.
 - `loadIngredients()` / `loadDrinks()` – hydrate the UI state from the API and trigger rendering.
-- `updateIngredientCatalog()` – keeps the datalist suggestions for ingredient names current.
+- `updateIngredientCatalog()` – keeps the ingredient suggestions in sync for the fridge datalist and the drink form dropdown.
 - `syncDrinkAvailability()` – merges fridge stock levels into each drink so availability badges stay accurate.
 - `renderIngredients()` / `renderDrinks()` – build the DOM for the fridge pills and drink cards, including empty states and badges.
 - `summariseDrink(drink)` / `shouldDisplayDrink(drink)` – compute aggregate stats, support readiness filters, and match the search box.
-- `summariseDrink(drink)` / `shouldDisplayDrink(drink)` – compute aggregate stats for filtering and status messaging.

--- a/app.js
+++ b/app.js
@@ -187,6 +187,7 @@ function updateIngredientCatalog() {
     placeholder.value = '';
     placeholder.disabled = true;
     placeholder.selected = true;
+    placeholder.hidden = true;
     placeholder.textContent = 'Select an ingredient';
     elements.drinkIngredientSelect.append(placeholder);
 
@@ -416,7 +417,7 @@ function renderSelectedDrinkIngredients() {
   if (state.drinkFormIngredients.length === 0) {
     const empty = document.createElement('li');
     empty.className = 'selector-empty';
-    empty.textContent = 'No ingredients yet. Choose from the dropdown below.';
+    empty.textContent = 'No ingredients yet. Choose an ingredient below and press Add.';
     list.append(empty);
     return;
   }
@@ -528,6 +529,7 @@ function resetDrinkForm() {
   }
   renderSelectedDrinkIngredients();
   updateDrinkFormState();
+  scheduleDrinksPanelHeightUpdate();
 }
 
 function summariseDrink(drink) {
@@ -839,10 +841,6 @@ function handleDrinkSearchInput(event) {
   renderDrinks();
 }
 
-function handleDrinkIngredientSelection(event) {
-  addDrinkIngredient(event.target.value);
-}
-
 function handleSelectedIngredientClick(event) {
   const button = event.target.closest('button[data-index]');
   if (!button) return;
@@ -864,6 +862,21 @@ function handleAddDrinkPanelToggle() {
   }
 }
 
+function handleDrinkIngredientChange() {
+  if (elements.drinkIngredientSelect) {
+    elements.drinkIngredientSelect.setCustomValidity('');
+  }
+}
+
+function handleDrinkIngredientKeydown(event) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    if (elements.drinkIngredientSelect) {
+      addDrinkIngredient(elements.drinkIngredientSelect.value);
+    }
+  }
+}
+
 function setupEventListeners() {
   elements.ingredientForm?.addEventListener('submit', handleIngredientSubmit);
   elements.ingredientCategory?.addEventListener('change', () => {
@@ -875,7 +888,8 @@ function setupEventListeners() {
   elements.drinkForm?.addEventListener('submit', handleDrinkSubmit);
   elements.filterGroup?.addEventListener('click', handleFilterClick);
   elements.drinkSearch?.addEventListener('input', handleDrinkSearchInput);
-  elements.drinkIngredientSelect?.addEventListener('change', handleDrinkIngredientSelection);
+  elements.drinkIngredientSelect?.addEventListener('change', handleDrinkIngredientChange);
+  elements.drinkIngredientSelect?.addEventListener('keydown', handleDrinkIngredientKeydown);
   elements.selectedDrinkIngredients?.addEventListener('click', handleSelectedIngredientClick);
   elements.addIngredientToDrink?.addEventListener('click', handleAddIngredientButton);
   elements.addDrinkPanel?.addEventListener('toggle', handleAddDrinkPanelToggle);

--- a/app.js
+++ b/app.js
@@ -405,7 +405,7 @@ function resolveIngredientName(value) {
   const cleanValue = normaliseIngredientInput(value || '');
   if (!cleanValue) return '';
   const existing = state.ingredients.find((item) => item.name.toLowerCase() === cleanValue.toLowerCase());
-  return existing ? existing.name : '';
+  return existing ? existing.name : cleanValue;
 }
 
 function renderSelectedDrinkIngredients() {

--- a/app.js
+++ b/app.js
@@ -27,9 +27,9 @@ const elements = {
   resetInventory: document.getElementById('reset-inventory'),
   ingredientCatalog: document.getElementById('ingredient-catalog'),
   drinkForm: document.getElementById('add-drink-form'),
+  addDrinkPanel: document.getElementById('add-drink-panel'),
   drinkName: document.getElementById('drink-name'),
-  drinkIngredientSearch: document.getElementById('drink-ingredient-search'),
-  drinkIngredientCatalog: document.getElementById('drink-ingredient-catalog'),
+  drinkIngredientSelect: document.getElementById('drink-ingredient-select'),
   selectedDrinkIngredients: document.getElementById('selected-ingredients'),
   addIngredientToDrink: document.getElementById('add-ingredient-to-drink'),
   drinkIngredients: document.getElementById('drink-ingredients'),
@@ -169,19 +169,43 @@ async function loadDrinks() {
 }
 
 function updateIngredientCatalog() {
-  if (!elements.ingredientCatalog || !elements.drinkIngredientCatalog) return;
+  if (!elements.ingredientCatalog) return;
 
   elements.ingredientCatalog.innerHTML = '';
-  elements.drinkIngredientCatalog.innerHTML = '';
   const sorted = [...state.ingredients].sort((a, b) => a.name.localeCompare(b.name));
   for (const ingredient of sorted) {
     const option = document.createElement('option');
     option.value = ingredient.name;
     elements.ingredientCatalog.append(option);
+  }
 
-    const drinkOption = document.createElement('option');
-    drinkOption.value = ingredient.name;
-    elements.drinkIngredientCatalog.append(drinkOption);
+  if (elements.drinkIngredientSelect) {
+    const previousValue = elements.drinkIngredientSelect.value;
+    elements.drinkIngredientSelect.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    placeholder.textContent = 'Select an ingredient';
+    elements.drinkIngredientSelect.append(placeholder);
+
+    for (const ingredient of sorted) {
+      const drinkOption = document.createElement('option');
+      drinkOption.value = ingredient.name;
+      drinkOption.textContent = ingredient.name;
+      elements.drinkIngredientSelect.append(drinkOption);
+    }
+
+    if (previousValue && sorted.some((item) => item.name === previousValue)) {
+      elements.drinkIngredientSelect.value = previousValue;
+      placeholder.selected = false;
+    } else {
+      elements.drinkIngredientSelect.value = '';
+      if (elements.drinkIngredientSelect.options.length > 0) {
+        elements.drinkIngredientSelect.options[0].selected = true;
+      }
+    }
   }
 }
 
@@ -380,7 +404,7 @@ function resolveIngredientName(value) {
   const cleanValue = normaliseIngredientInput(value || '');
   if (!cleanValue) return '';
   const existing = state.ingredients.find((item) => item.name.toLowerCase() === cleanValue.toLowerCase());
-  return existing ? existing.name : cleanValue;
+  return existing ? existing.name : '';
 }
 
 function renderSelectedDrinkIngredients() {
@@ -392,7 +416,7 @@ function renderSelectedDrinkIngredients() {
   if (state.drinkFormIngredients.length === 0) {
     const empty = document.createElement('li');
     empty.className = 'selector-empty';
-    empty.textContent = 'No ingredients yet. Search and add from the field below.';
+    empty.textContent = 'No ingredients yet. Choose from the dropdown below.';
     list.append(empty);
     return;
   }
@@ -420,26 +444,48 @@ function updateDrinkFormState() {
   if (elements.drinkIngredients) {
     elements.drinkIngredients.value = state.drinkFormIngredients.join(', ');
   }
-  if (elements.drinkIngredientSearch && state.drinkFormIngredients.length > 0) {
-    elements.drinkIngredientSearch.setCustomValidity('');
+  if (elements.drinkIngredientSelect && state.drinkFormIngredients.length > 0) {
+    elements.drinkIngredientSelect.setCustomValidity('');
   }
 }
 
 function addDrinkIngredient(rawValue) {
-  const resolvedName = resolveIngredientName(rawValue || '');
-  if (!resolvedName) {
-    if (elements.drinkIngredientSearch) {
-      elements.drinkIngredientSearch.value = '';
+  const inputValue = normaliseIngredientInput(rawValue || '');
+  if (!inputValue) {
+    if (elements.drinkIngredientSelect) {
+      elements.drinkIngredientSelect.value = '';
+      elements.drinkIngredientSelect.setCustomValidity('');
+      if (elements.drinkIngredientSelect.options.length > 0) {
+        elements.drinkIngredientSelect.selectedIndex = 0;
+      }
     }
     return;
+  }
+
+  const resolvedName = resolveIngredientName(inputValue);
+  if (!resolvedName) {
+    if (elements.drinkIngredientSelect) {
+      elements.drinkIngredientSelect.setCustomValidity(
+        'Select an ingredient that already exists in your fridge and pantry.'
+      );
+      elements.drinkIngredientSelect.reportValidity();
+    }
+    return;
+  }
+
+  if (elements.drinkIngredientSelect) {
+    elements.drinkIngredientSelect.setCustomValidity('');
   }
 
   const exists = state.drinkFormIngredients.some(
     (item) => item.toLowerCase() === resolvedName.toLowerCase()
   );
   if (exists) {
-    if (elements.drinkIngredientSearch) {
-      elements.drinkIngredientSearch.value = '';
+    if (elements.drinkIngredientSelect) {
+      elements.drinkIngredientSelect.value = '';
+      if (elements.drinkIngredientSelect.options.length > 0) {
+        elements.drinkIngredientSelect.selectedIndex = 0;
+      }
     }
     return;
   }
@@ -447,9 +493,12 @@ function addDrinkIngredient(rawValue) {
   state.drinkFormIngredients.push(resolvedName);
   renderSelectedDrinkIngredients();
   updateDrinkFormState();
-  if (elements.drinkIngredientSearch) {
-    elements.drinkIngredientSearch.value = '';
-    elements.drinkIngredientSearch.focus();
+  if (elements.drinkIngredientSelect) {
+    elements.drinkIngredientSelect.value = '';
+    if (elements.drinkIngredientSelect.options.length > 0) {
+      elements.drinkIngredientSelect.selectedIndex = 0;
+    }
+    elements.drinkIngredientSelect.focus();
   }
 }
 
@@ -467,9 +516,15 @@ function resetDrinkForm() {
   if (elements.drinkForm) {
     elements.drinkForm.reset();
   }
-  if (elements.drinkIngredientSearch) {
-    elements.drinkIngredientSearch.value = '';
-    elements.drinkIngredientSearch.setCustomValidity('');
+  if (elements.addDrinkPanel) {
+    elements.addDrinkPanel.removeAttribute('open');
+  }
+  if (elements.drinkIngredientSelect) {
+    elements.drinkIngredientSelect.value = '';
+    if (elements.drinkIngredientSelect.options.length > 0) {
+      elements.drinkIngredientSelect.selectedIndex = 0;
+    }
+    elements.drinkIngredientSelect.setCustomValidity('');
   }
   renderSelectedDrinkIngredients();
   updateDrinkFormState();
@@ -739,8 +794,8 @@ async function handleResetInventory() {
 
 async function handleDrinkSubmit(event) {
   event.preventDefault();
-  if (elements.drinkIngredientSearch) {
-    elements.drinkIngredientSearch.setCustomValidity('');
+  if (elements.drinkIngredientSelect) {
+    elements.drinkIngredientSelect.setCustomValidity('');
   }
 
   const name = elements.drinkName?.value.trim();
@@ -748,9 +803,9 @@ async function handleDrinkSubmit(event) {
   const ingredientsInput = state.drinkFormIngredients.map((value) => value.trim()).filter(Boolean);
 
   if (!name || !instructions || ingredientsInput.length === 0) {
-    if (ingredientsInput.length === 0 && elements.drinkIngredientSearch) {
-      elements.drinkIngredientSearch.setCustomValidity('Add at least one ingredient to the drink.');
-      elements.drinkIngredientSearch.reportValidity();
+    if (ingredientsInput.length === 0 && elements.drinkIngredientSelect) {
+      elements.drinkIngredientSelect.setCustomValidity('Add at least one ingredient to the drink.');
+      elements.drinkIngredientSelect.reportValidity();
     } else if (elements.drinkForm) {
       elements.drinkForm.reportValidity();
     }
@@ -788,15 +843,6 @@ function handleDrinkIngredientSelection(event) {
   addDrinkIngredient(event.target.value);
 }
 
-function handleDrinkIngredientKeydown(event) {
-  if (event.key === 'Enter') {
-    event.preventDefault();
-    addDrinkIngredient(event.target.value);
-  } else if (event.key === 'Backspace' && event.target.value === '') {
-    removeDrinkIngredient(state.drinkFormIngredients.length - 1);
-  }
-}
-
 function handleSelectedIngredientClick(event) {
   const button = event.target.closest('button[data-index]');
   if (!button) return;
@@ -806,8 +852,15 @@ function handleSelectedIngredientClick(event) {
 }
 
 function handleAddIngredientButton() {
-  if (elements.drinkIngredientSearch) {
-    addDrinkIngredient(elements.drinkIngredientSearch.value);
+  if (elements.drinkIngredientSelect) {
+    addDrinkIngredient(elements.drinkIngredientSelect.value);
+  }
+}
+
+function handleAddDrinkPanelToggle() {
+  scheduleDrinksPanelHeightUpdate();
+  if (elements.addDrinkPanel?.open && elements.drinkName) {
+    elements.drinkName.focus();
   }
 }
 
@@ -822,10 +875,10 @@ function setupEventListeners() {
   elements.drinkForm?.addEventListener('submit', handleDrinkSubmit);
   elements.filterGroup?.addEventListener('click', handleFilterClick);
   elements.drinkSearch?.addEventListener('input', handleDrinkSearchInput);
-  elements.drinkIngredientSearch?.addEventListener('change', handleDrinkIngredientSelection);
-  elements.drinkIngredientSearch?.addEventListener('keydown', handleDrinkIngredientKeydown);
+  elements.drinkIngredientSelect?.addEventListener('change', handleDrinkIngredientSelection);
   elements.selectedDrinkIngredients?.addEventListener('click', handleSelectedIngredientClick);
   elements.addIngredientToDrink?.addEventListener('click', handleAddIngredientButton);
+  elements.addDrinkPanel?.addEventListener('toggle', handleAddDrinkPanelToggle);
   elements.themeToggle?.addEventListener('click', handleThemeToggle);
 }
 

--- a/index.html
+++ b/index.html
@@ -73,45 +73,47 @@
         <p>Browse existing drinks or add your own favourites.</p>
       </div>
 
-      <form id="add-drink-form" class="stacked-form" autocomplete="off">
-        <div class="form-row">
-          <label class="form-control">
-            <span>Drink name</span>
-            <input type="text" id="drink-name" placeholder="e.g. French 75" required />
-          </label>
-          <label class="form-control">
-            <span>Ingredients</span>
-            <div class="ingredient-selector">
-              <ul
-                id="selected-ingredients"
-                class="selected-ingredients"
-                aria-live="polite"
-                aria-label="Selected ingredients"
-              ></ul>
-              <div class="selector-controls">
-                <input
-                  type="text"
-                  id="drink-ingredient-search"
-                  list="drink-ingredient-catalog"
-                  placeholder="Search ingredients"
-                  aria-describedby="drink-ingredient-help"
-                />
-                <button type="button" id="add-ingredient-to-drink" class="secondary-btn">Add</button>
+      <details id="add-drink-panel" class="add-drink-panel">
+        <summary class="add-drink-summary">Add a new drink</summary>
+        <form id="add-drink-form" class="stacked-form" autocomplete="off">
+          <div class="form-row">
+            <label class="form-control">
+              <span>Drink name</span>
+              <input type="text" id="drink-name" placeholder="e.g. French 75" required />
+            </label>
+            <label class="form-control">
+              <span>Ingredients</span>
+              <div class="ingredient-selector">
+                <ul
+                  id="selected-ingredients"
+                  class="selected-ingredients"
+                  aria-live="polite"
+                  aria-label="Selected ingredients"
+                ></ul>
+                <div class="selector-controls">
+                  <select
+                    id="drink-ingredient-select"
+                    aria-describedby="drink-ingredient-help"
+                  >
+                    <option value="" disabled selected hidden>Select an ingredient</option>
+                  </select>
+                  <button type="button" id="add-ingredient-to-drink" class="secondary-btn">Add</button>
+                </div>
               </div>
-            </div>
-            <p class="field-help" id="drink-ingredient-help">
-              Search your fridge for existing ingredients or type a new one and press Add.
-            </p>
-            <input type="hidden" id="drink-ingredients" />
+              <p class="field-help" id="drink-ingredient-help">
+                Pick from the ingredients already saved in your fridge and press Add.
+              </p>
+              <input type="hidden" id="drink-ingredients" />
+            </label>
+          </div>
+
+          <label class="form-control">
+            <span>Recipe / Instructions</span>
+            <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>
           </label>
-        </div>
-        <datalist id="drink-ingredient-catalog"></datalist>
-        <label class="form-control">
-          <span>Recipe / Instructions</span>
-          <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>
-        </label>
-        <button type="submit" class="primary-btn">Add drink</button>
-      </form>
+          <button type="submit" class="primary-btn">Add drink</button>
+        </form>
+      </details>
 
       <div class="drink-toolbar">
         <label class="drink-search">
@@ -162,23 +164,22 @@
               aria-label="Selected ingredients"
             ></ul>
             <div class="selector-controls">
-              <input
-                type="text"
-                id="drink-ingredient-search"
-                list="drink-ingredient-catalog"
-                placeholder="Search ingredients"
+              <select
+                id="drink-ingredient-select"
                 aria-describedby="drink-ingredient-help"
-              />
+              >
+                <option value="" disabled selected hidden>Select an ingredient</option>
+              </select>
               <button type="button" id="add-ingredient-to-drink" class="secondary-btn">Add</button>
             </div>
           </div>
           <p class="field-help" id="drink-ingredient-help">
-            Search your fridge for existing ingredients or type a new one and press Add.
+            Pick from the ingredients already saved in your fridge and press Add.
           </p>
           <input type="hidden" id="drink-ingredients" />
         </label>
       </div>
-      <datalist id="drink-ingredient-catalog"></datalist>
+      
       <label class="form-control">
         <span>Recipe / Instructions</span>
         <textarea id="drink-recipe" rows="3" placeholder="Write the preparation steps" required></textarea>

--- a/styles.css
+++ b/styles.css
@@ -345,6 +345,71 @@ body.modal-open-fallback::after {
   margin-bottom: 1.5rem;
 }
 
+.add-drink-panel {
+  margin: 0 0 1.5rem;
+  border: 1px solid var(--card-border);
+  border-radius: 14px;
+  background: var(--card-bg);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.add-drink-panel:not([open]) {
+  margin-bottom: 1rem;
+  background: transparent;
+}
+
+.add-drink-panel[open] {
+  background: var(--card-bg);
+}
+
+.add-drink-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--summary-text);
+  list-style: none;
+  background: var(--card-bg);
+  border-radius: 14px;
+}
+
+.add-drink-summary::-webkit-details-marker {
+  display: none;
+}
+
+.add-drink-summary:focus-visible {
+  outline: 2px solid var(--summary-marker);
+  outline-offset: 2px;
+}
+
+.add-drink-summary::before {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid var(--summary-marker);
+  border-bottom: 2px solid var(--summary-marker);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.add-drink-panel[open] .add-drink-summary::before {
+  transform: rotate(225deg);
+}
+
+.add-drink-panel[open] .add-drink-summary {
+  border-radius: 14px 14px 0 0;
+  border-bottom: 1px solid var(--card-border);
+}
+
+.add-drink-panel > .stacked-form {
+  margin: 0;
+  padding: 0 1.1rem 1.1rem;
+  border-top: 1px solid var(--card-border);
+}
+
 .form-control {
   display: grid;
   gap: 0.35rem;


### PR DESCRIPTION
## Summary
- wrap the inline add drink form in an expandable details panel so it stays hidden until expanded
- add styling and behaviour for the disclosure summary, including a custom arrow indicator and auto-focus when opened
- collapse the panel after a successful submission while keeping the drinks list layout measurements in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecac234798832696ffc22958742d14